### PR TITLE
fix: strip inner quotes from article name in invoice quick links

### DIFF
--- a/frontend/src/views/client/modules/articles/components/article-details.tsx
+++ b/frontend/src/views/client/modules/articles/components/article-details.tsx
@@ -53,10 +53,12 @@ export const ArticlesDetailsPage = ({
       | "supplier_quotes"
       | "supplier_invoices" = "invoices",
   ) => {
+    // Parser regex [^"]* can't handle inner quotes; stripping them is safe because the map resolves to the article ID.
+    const safeName = draft.name.replace(/"/g, "");
     const query = [
-      `q=${encodeURIComponent(`articles.all:"${draft.name}"`)}`,
+      `q=${encodeURIComponent(`articles.all:"${safeName}"`)}`,
       `map=${encodeURIComponent(
-        JSON.stringify({ [`articles.all:${draft.name}`]: draft.id }),
+        JSON.stringify({ [`articles.all:${safeName}`]: draft.id }),
       )}`,
     ].join("&");
     return getRoute(ROUTES.Invoices, { type }) + "?" + query;

--- a/frontend/src/views/client/modules/articles/components/article-details.tsx
+++ b/frontend/src/views/client/modules/articles/components/article-details.tsx
@@ -54,7 +54,7 @@ export const ArticlesDetailsPage = ({
       | "supplier_invoices" = "invoices",
   ) => {
     // Parser regex [^"]* can't handle inner quotes; stripping them is safe because the map resolves to the article ID.
-    const safeName = draft.name.replace(/"/g, "");
+    const safeName = draft.name.replace(/"/g, " ");
     const query = [
       `q=${encodeURIComponent(`articles.all:"${safeName}"`)}`,
       `map=${encodeURIComponent(


### PR DESCRIPTION
## Summary

- Article names containing `"` (e.g. screen sizes like `24"`) broke the quick links from the article view to invoices/quotes.
- The search bar parser uses `[^"]*` in its regex, which stops at the first inner double quote, corrupting both the query value and the `map` key.
- Fix: strip double quotes from the article name when building the `q` and `map` URL params. This is safe because the `map` still maps the sanitized display text to the article ID, so the backend query always resolves to the correct article.

## Test plan

- [ ] Open an article whose name contains a `"` (e.g. a monitor with `24"` in the name)
- [ ] Click the quick link "Factures" (or Devis, Commandes, Factures fournisseur)
- [ ] Verify the invoices page opens with the correct filter applied and returns results for that article
- [ ] Verify the search bar shows a readable filter label (name without inner quotes)
- [ ] Repeat with an article name that has no `"` to confirm no regression

https://claude.ai/code/session_012yHK9pu4ytLnWA6UcwCTNe

---
_Generated by [Claude Code](https://claude.ai/code/session_012yHK9pu4ytLnWA6UcwCTNe)_