### PR TITLE
Add numeric prefix expansion for article and stock item search

### DIFF
--- a/backend/src/services/migrations/index.ts
+++ b/backend/src/services/migrations/index.ts
@@ -22,6 +22,7 @@ import { convertUnitsToStandardCodes } from "./migrations/014-convert-units-to-s
 import { convertVatExemptionsToStandardCodes } from "./migrations/015-convert-vat-exemptions-to-standard-codes";
 import { convertVatToStandardCodes } from "./migrations/016-convert-vat-to-standard-codes";
 import { normalizeContactCountryCodes } from "./migrations/017-normalize-contact-country-codes";
+import { reindexArticlesStockNumericPrefixes } from "./migrations/018-reindex-articles-stock-numeric-prefixes";
 
 export default class Clients implements InternalApplicationService {
   version = 1;
@@ -79,6 +80,7 @@ export default class Clients implements InternalApplicationService {
         convertVatExemptionsToStandardCodes,
       "016-convert-vat-to-standard-codes": convertVatToStandardCodes,
       "017-normalize-contact-country-codes": normalizeContactCountryCodes,
+      "018-reindex-articles-stock-numeric-prefixes": reindexArticlesStockNumericPrefixes,
     } as {
       [key: string]: (ctx: Context) => Promise<void>;
     };

--- a/backend/src/services/migrations/migrations/018-reindex-articles-stock-numeric-prefixes.ts
+++ b/backend/src/services/migrations/migrations/018-reindex-articles-stock-numeric-prefixes.ts
@@ -1,0 +1,53 @@
+import Framework from "#src/platform/index";
+import Articles, {
+  ArticlesDefinition,
+} from "#src/services/modules/articles/entities/articles";
+import StockItems, {
+  StockItemsDefinition,
+} from "#src/services/modules/stock/entities/stock-items";
+import { expandSearchable } from "#src/services/rest/services/rest";
+import { Context } from "#src/types";
+
+export const reindexArticlesStockNumericPrefixes = async (ctx: Context) => {
+  const db = await Framework.Db.getService();
+
+  let items: Articles[] = [];
+  let offset = 0;
+  do {
+    items = await db.select<Articles>(ctx, ArticlesDefinition.name, {}, { offset, limit: 1000, index: "id" });
+    for (const entity of items) {
+      await db.update<Articles>(
+        ctx,
+        ArticlesDefinition.name,
+        { id: entity.id, client_id: entity.client_id },
+        {
+          searchable: expandSearchable(
+            Framework.TriggersManager.getEntities()[ArticlesDefinition.name].rest.searchable(entity)
+          ),
+        },
+        { triggers: false }
+      );
+    }
+    offset += items.length;
+  } while (items.length > 0);
+
+  let stockItems: StockItems[] = [];
+  offset = 0;
+  do {
+    stockItems = await db.select<StockItems>(ctx, StockItemsDefinition.name, {}, { offset, limit: 1000, index: "id" });
+    for (const entity of stockItems) {
+      await db.update<StockItems>(
+        ctx,
+        StockItemsDefinition.name,
+        { id: entity.id, client_id: entity.client_id },
+        {
+          searchable: expandSearchable(
+            Framework.TriggersManager.getEntities()[StockItemsDefinition.name].rest.searchable(entity)
+          ),
+        },
+        { triggers: false }
+      );
+    }
+    offset += stockItems.length;
+  } while (stockItems.length > 0);
+};

--- a/backend/src/services/modules/articles/entities/articles.ts
+++ b/backend/src/services/modules/articles/entities/articles.ts
@@ -10,6 +10,7 @@ import {
   RestEntityColumnsDefinition,
 } from "../../../rest/entities/entity";
 import { flattenKeys } from "../../../utils";
+import { expandNumericPrefixes } from "../../../rest/services/rest";
 
 export default class Articles extends RestEntity {
   assigned = ["type:users"];
@@ -84,11 +85,13 @@ export const ArticlesDefinition: RestTableDefinition = {
     searchable: (entity: Articles) => {
       return [
         Object.values(flattenKeys(_.pick(entity, ["name"]))).join(" "),
-        Object.values(flattenKeys(_.pick(entity, ["internal_reference"]))).join(
-          " "
+        expandNumericPrefixes(
+          Object.values(
+            flattenKeys(_.pick(entity, ["internal_reference"]))
+          ).join(" ")
         ),
         Object.values(entity.suppliers_details || [])
-          .map((a) => a.reference)
+          .map((a) => expandNumericPrefixes(a.reference))
           .join(" "),
         Object.values(flattenKeys(_.pick(entity, ["notes"]))).join(" "),
       ];

--- a/backend/src/services/modules/stock/entities/stock-items.ts
+++ b/backend/src/services/modules/stock/entities/stock-items.ts
@@ -10,6 +10,7 @@ import {
   RestEntityColumnsDefinition,
 } from "../../../rest/entities/entity";
 import { flattenKeys } from "../../../utils";
+import { expandNumericPrefixes } from "../../../rest/services/rest";
 
 /**
  * Stock:
@@ -72,7 +73,9 @@ export const StockItemsDefinition: RestTableDefinition = {
     label: (entity: StockItems) => entity.serial_number,
     searchable: (entity: StockItems) => {
       return [
-        ...Object.values(flattenKeys(_.pick(entity, ["serial_number"]))),
+        ...Object.values(flattenKeys(_.pick(entity, ["serial_number"]))).map(
+          expandNumericPrefixes
+        ),
         (entity.serial_number || "").split("").reverse().join(""),
         entity.cache?.article_name || "",
         entity.cache?.client_name || "",

--- a/backend/src/services/rest/services/rest-searchable.spec.ts
+++ b/backend/src/services/rest/services/rest-searchable.spec.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "@jest/globals";
-import { expandSearchable } from "./rest";
+import { expandSearchable, expandNumericPrefixes } from "./rest";
 
 describe("rest-searchable", () => {
   test("rest-searchable", () => {
@@ -16,5 +16,18 @@ describe("rest-searchable", () => {
       "Ingram"
     );
     expect(expandSearchable("12G")).toContain("12 G");
+  });
+
+  test("expandNumericPrefixes", () => {
+    // Generates prefixes for numeric segments of length >= 3
+    expect(expandNumericPrefixes("TSU-001001-R")).toContain("001");
+    expect(expandNumericPrefixes("TSU-001001-R")).toContain("0010");
+    expect(expandNumericPrefixes("TSU-001001-R")).toContain("00100");
+    // Full segment already present via expandSearchable, not duplicated here
+    expect(expandNumericPrefixes("TSU-001001-R")).not.toContain("001001 001001");
+    // Short segments (< 3) produce no extra tokens
+    expect(expandNumericPrefixes("AB-12-C")).toBe("AB-12-C");
+    // No numeric segment at all
+    expect(expandNumericPrefixes("REFABC")).toBe("REFABC");
   });
 });

--- a/backend/src/services/rest/services/rest.ts
+++ b/backend/src/services/rest/services/rest.ts
@@ -448,6 +448,19 @@ const orderSearchResults = (items: RestEntity[], query: string) => {
   );
 };
 
+// For a reference string, generates all prefixes of each numeric segment (min length 3),
+// so that partial searches like "TSU-001" match "TSU-001001-R".
+export const expandNumericPrefixes = (str: string): string => {
+  const MIN_PREFIX_LENGTH = 3;
+  const extra: string[] = [];
+  for (const segment of str.match(/\d+/g) || []) {
+    for (let len = MIN_PREFIX_LENGTH; len < segment.length; len++) {
+      extra.push(segment.slice(0, len));
+    }
+  }
+  return extra.length > 0 ? str + " " + extra.join(" ") : str;
+};
+
 // string: single priority, string[]: multiple priority with first: highest
 export const expandSearchable = (searchable: string | string[]) => {
   if (_.isArray(searchable)) {


### PR DESCRIPTION
## Summary

Enhance full-text search for articles and stock items by generating searchable prefixes for numeric segments in reference numbers. This allows partial searches like "TSU-001" to match full references like "TSU-001001-R".

## Changes

- **New utility function `expandNumericPrefixes()`** in `rest.ts`: Generates all prefixes of numeric segments with length ≥ 3, enabling progressive matching of numeric codes
  - Example: "TSU-001001-R" expands to include "001", "0010", "00100" as searchable tokens
  - Short numeric segments (< 3 digits) are skipped to avoid noise

- **Updated searchable fields** for Articles and Stock Items:
  - Articles: Apply `expandNumericPrefixes()` to `internal_reference` and supplier reference fields
  - Stock Items: Apply `expandNumericPrefixes()` to `serial_number` field

- **New migration (018)** `reindex-articles-stock-numeric-prefixes.ts`:
  - Batch reindexes all existing articles and stock items (1000 items per batch)
  - Regenerates searchable fields with the new numeric prefix expansion logic
  - Disables triggers during reindexing for performance

- **Test coverage** added for `expandNumericPrefixes()` with edge cases:
  - Numeric segments ≥ 3 digits generate prefixes
  - Short segments (< 3) produce no extra tokens
  - Non-numeric strings pass through unchanged

## Implementation Details

The `expandNumericPrefixes()` function extracts all numeric segments from a string and generates all prefixes starting from length 3 up to (but not including) the full segment length. This allows users to progressively narrow searches without needing to know the complete reference number format.

The migration ensures backward compatibility by reindexing existing data with the new search logic, maintaining consistency across the database.

https://claude.ai/code/session_01NXg8yXUnnpzWobRmFNzmqT