### PR TITLE
feat(invoices): allow realigning subscription billing day from a generated invoice

### DIFF
--- a/backend/src/services/modules/comments/entities/comments.ts
+++ b/backend/src/services/modules/comments/entities/comments.ts
@@ -36,6 +36,10 @@ export type EventMetadatas =
   | {
       event_type: "invoice_back_to_draft";
       reason: string;
+    }
+  | {
+      event_type: "subscription_billing_day_updated";
+      from_invoice: string;
     };
 
 export default class Comments extends RestEntity {

--- a/backend/src/services/modules/invoices/routes.ts
+++ b/backend/src/services/modules/invoices/routes.ts
@@ -160,6 +160,87 @@ export const registerRoutes = (router: Router) => {
     }
   );
 
+  // Realign the billing day of the source recurring quote(s) based on a
+  // generated invoice's period start. Used when a user edits the billing period
+  // of a generated (or manual) invoice and wants the future invoices of the
+  // subscription to follow the new day (e.g. bringing periods back to the 1st of
+  // the month instead of the day the first invoice happened to be sent).
+  router.post(
+    "/:clientId/invoice/:id/sync-subscription-day",
+    checkRole("USER"),
+    async (req, res) => {
+      const ctx = Ctx.get(req)!.context;
+      const db = await Framework.Db.getService();
+
+      const invoice = await db.selectOne<Invoices>(
+        ctx,
+        InvoicesDefinition.name,
+        {
+          id: req.params.id,
+          client_id: ctx.client_id,
+        }
+      );
+      if (!invoice) return res.status(404).json({ error: "Not found" });
+
+      const from = req.body?.from ?? invoice.from_subscription?.from;
+      if (!from || !invoice.from_rel_quote?.length) {
+        return res
+          .status(400)
+          .json({ error: "Invoice is not linked to a subscription period" });
+      }
+
+      // The period boundaries of generated invoices are anchored on the source
+      // quote's subscription_started_at (applyOffset preserves the day-of-month,
+      // weekday or month/day depending on the frequency). Realigning that anchor
+      // on the chosen period start is therefore enough to shift the billing day.
+      const newStartedAt = new Date(from);
+      const updated: string[] = [];
+
+      for (const quoteId of invoice.from_rel_quote) {
+        const quote = await db.selectOne<Invoices>(
+          ctx,
+          InvoicesDefinition.name,
+          {
+            id: quoteId,
+            client_id: ctx.client_id,
+          }
+        );
+        if (!quote || quote.type !== "quotes" || quote.state !== "recurring") {
+          continue;
+        }
+
+        await db.update<Invoices>(
+          ctx,
+          InvoicesDefinition.name,
+          { id: quote.id, client_id: quote.client_id },
+          {
+            subscription_started_at: newStartedAt,
+            // Force the next cron run to recompute the upcoming periods from the
+            // new anchor (already-invoiced periods are skipped by the dedup).
+            subscription_next_invoice_date: newStartedAt,
+          }
+        );
+
+        await Services.Comments.createEvent(ctx, {
+          client_id: quote.client_id,
+          item_entity: "invoices",
+          item_id: quote.id,
+          content: `Le jour de facturation de l'abonnement a été aligné sur le ${
+            newStartedAt.toISOString().split("T")[0]
+          } depuis la facture ${invoice.reference || invoice.id}.`,
+          metadata: {
+            event_type: "subscription_billing_day_updated",
+            from_invoice: invoice.id,
+          },
+        });
+
+        updated.push(quote.id);
+      }
+
+      return res.json({ ok: true, updated });
+    }
+  );
+
   router.post(
     "/:clientId/furnish-invoices",
     checkRole("USER"),

--- a/frontend/src/features/invoices/api-client/invoices-api-client.ts
+++ b/frontend/src/features/invoices/api-client/invoices-api-client.ts
@@ -60,6 +60,22 @@ export class InvoicesApiClient {
     return res.json();
   }
 
+  // Realign the billing day of the source recurring quote linked to this
+  // invoice on the given period start (timestamp in ms).
+  static async syncSubscriptionDay(
+    invoice: Pick<Invoices, "id" | "client_id">,
+    from: number
+  ) {
+    const res = await fetchServer(
+      `/api/invoices/v1/${invoice.client_id}/invoice/${invoice.id}/sync-subscription-day`,
+      {
+        method: "POST",
+        body: JSON.stringify({ from }),
+      }
+    );
+    return res.json();
+  }
+
   static async getPartialInvoice(
     invoice: Pick<Invoices, "id" | "client_id">,
     selection: Partial<InvoiceLine>[] = []

--- a/frontend/src/views/client/modules/invoices/components/input-recurrence-period.tsx
+++ b/frontend/src/views/client/modules/invoices/components/input-recurrence-period.tsx
@@ -6,20 +6,31 @@ import { format } from "date-fns";
 import { Text } from "@radix-ui/themes";
 import { FormInput } from "@components/form/fields";
 import { Checkbox } from "@atoms/input/input-checkbox";
+import { Info } from "@atoms/text";
 import { useEffect, useState } from "react";
 import { applyOffset } from "@shared/invoices";
+import { atomFamily, useRecoilState } from "recoil";
 import _ from "lodash";
+
+// Holds, per invoice, whether the user asked to realign the billing day of the
+// source subscription when saving. Read by the edit page on save.
+export const SyncSubscriptionDayAtom = atomFamily<boolean, string>({
+  key: "SyncSubscriptionDayAtom",
+  default: false,
+});
 
 export const InvoiceRecurrencePeriodInput = ({
   ctrl,
   invoice,
   readonly,
   btnKey,
+  sourceQuote,
 }: {
   ctrl: FormControllerFuncType<Invoices>;
   invoice: Invoices;
   readonly?: boolean;
   btnKey?: string;
+  sourceQuote?: Invoices;
 }) => {
   const frequencies = _.uniq(
     invoice.content?.filter((a) => a.subscription).map((a) => a.subscription),
@@ -54,6 +65,34 @@ export const InvoiceRecurrencePeriodInput = ({
       new Date(invoice.from_subscription?.to).toISOString().split("T")[0];
 
   const [useCustomDate, setUseCustomDate] = useState(!!isCustomDate);
+
+  // When this invoice is linked to a still-active recurring quote, we let the
+  // user realign the subscription's billing day on the period start they just
+  // set. We only offer it when the day actually differs from the current one.
+  const fromDate = invoice.from_subscription?.from
+    ? new Date(invoice.from_subscription.from)
+    : null;
+  const subscriptionAnchor = sourceQuote?.subscription_started_at
+    ? new Date(sourceQuote.subscription_started_at)
+    : null;
+  const canSyncSubscriptionDay =
+    !readonly &&
+    !!invoice.from_rel_quote?.length &&
+    sourceQuote?.state === "recurring" &&
+    !!fromDate &&
+    !!subscriptionAnchor &&
+    fromDate.getDate() !== subscriptionAnchor.getDate();
+
+  const [syncSubscriptionDay, setSyncSubscriptionDay] = useRecoilState(
+    SyncSubscriptionDayAtom(invoice.id || "new"),
+  );
+
+  // Drop the intent if the period gets reverted to the existing billing day.
+  useEffect(() => {
+    if (!canSyncSubscriptionDay && syncSubscriptionDay) {
+      setSyncSubscriptionDay(false);
+    }
+  }, [canSyncSubscriptionDay]);
 
   useEffect(() => {
     if (!useCustomDate) {
@@ -112,6 +151,20 @@ export const InvoiceRecurrencePeriodInput = ({
               onChange={setUseCustomDate}
             />
           </div>
+          {canSyncSubscriptionDay && (
+            <div className="space-y-1 border-t border-slate-100 dark:border-slate-700 pt-3">
+              <Checkbox
+                label="Mettre à jour le jour de facturation de l'abonnement source"
+                value={syncSubscriptionDay}
+                onChange={setSyncSubscriptionDay}
+              />
+              <Info className="block">
+                Les prochaines factures de cet abonnement seront générées à
+                partir du {format(new Date(fromDate || Date.now()), "dd")} du
+                mois.
+              </Info>
+            </div>
+          )}
         </div>
       )}
       value={"true"}

--- a/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
+++ b/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
@@ -671,6 +671,7 @@ export const InvoicesDetailsPage = ({
                             invoice={draft}
                             ctrl={ctrl}
                             readonly={readonly}
+                            sourceQuote={originQuote || undefined}
                           />
                         </div>
                       )}

--- a/frontend/src/views/client/modules/invoices/edit/index.tsx
+++ b/frontend/src/views/client/modules/invoices/edit/index.tsx
@@ -6,13 +6,16 @@ import { useInvoiceDefaultModel } from "@features/invoices/configuration";
 import { Invoices } from "@features/invoices/types/types";
 import { getDocumentNamePlurial } from "@features/invoices/utils";
 import { ROUTES, getRoute } from "@features/routes";
+import { InvoicesApiClient } from "@features/invoices/api-client/invoices-api-client";
 import { useDraftRest } from "@features/utils/rest/hooks/use-draft-rest";
 import { Page } from "@views/client/_layout/page";
 import _ from "lodash";
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
 import { InvoicesDocumentBar } from "../components/document-bar";
 import { InvoicesDetailsPage } from "../components/invoices-details";
+import { SyncSubscriptionDayAtom } from "../components/input-recurrence-period";
 
 export const InvoicesEditPage = (_props: { readonly?: boolean }) => {
   const { refresh } = useClients();
@@ -27,6 +30,10 @@ export const InvoicesEditPage = (_props: { readonly?: boolean }) => {
 
   const defaultModel = useRef(useInvoiceDefaultModel()).current;
   const initialModel = getUrlModel<Invoices>();
+
+  const [syncSubscriptionDay, setSyncSubscriptionDay] = useRecoilState(
+    SyncSubscriptionDayAtom(id || "new"),
+  );
 
   const { isInitiating, save, draft, isPendingModification } =
     useDraftRest<Invoices>(
@@ -65,6 +72,22 @@ export const InvoicesEditPage = (_props: { readonly?: boolean }) => {
           onSave={async () => {
             const invoice = await save();
             if (invoice?.id) {
+              if (
+                syncSubscriptionDay &&
+                invoice.from_rel_quote?.length &&
+                invoice.from_subscription?.from
+              ) {
+                try {
+                  await InvoicesApiClient.syncSubscriptionDay(
+                    invoice,
+                    invoice.from_subscription.from
+                  );
+                } catch (e) {
+                  console.error(e);
+                } finally {
+                  setSyncSubscriptionDay(false);
+                }
+              }
               console.log("NAVIGATE TO VIEW");
               navigate(getRoute(ROUTES.InvoicesView, { id: invoice.id }));
             }


### PR DESCRIPTION
When a recurring quote's first invoice is sent on, say, the 12th, all
billing periods run from the 12th to the 11th. Users often want to bring
periods back to the 1st of the month. They could already edit the period
of a generated invoice, but that change did not propagate to the source
subscription, so the next invoices kept the old day.

Now, when editing the billing period of an invoice linked to an active
recurring quote, a checkbox "Mettre à jour le jour de facturation de
l'abonnement source" appears whenever the chosen period start lands on a
different day than the subscription's current billing day. On save, the
source quote's subscription_started_at anchor (which drives all future
period boundaries) is realigned on the new day so the next generated
invoices follow it.

- backend: POST /api/invoices/v1/:clientId/invoice/:id/sync-subscription-day
- backend: new "subscription_billing_day_updated" event for the audit trail
- frontend: checkbox in the recurrence-period editor + sync call on save