### PR TITLE
Add error handling for document deletion with toast notification

### DIFF
--- a/frontend/src/components/document-bar/ActionButtons.tsx
+++ b/frontend/src/components/document-bar/ActionButtons.tsx
@@ -13,6 +13,7 @@ import {
   PrinterIcon,
 } from "@heroicons/react/24/outline";
 import { useSetRecoilState } from "recoil";
+import toast from "react-hot-toast";
 import { getDuplicateDocumentData } from "./utils";
 
 interface ActionButtonsProps {
@@ -66,8 +67,12 @@ export const ActionButtons = ({
           {
             type: "danger" as const,
             label: "Supprimer",
-            onClick: () => {
-              onRemove?.();
+            onClick: async () => {
+              try {
+                await onRemove?.();
+              } catch {
+                toast.error("Impossible de supprimer le document");
+              }
             },
           },
         ]


### PR DESCRIPTION
## Summary

Added error handling and user feedback for the document deletion action in the ActionButtons component. When a document deletion fails, users now receive a toast notification instead of a silent failure.

## Changes

- Imported `react-hot-toast` for user notifications
- Modified the delete button's `onClick` handler to be async and wrap the `onRemove` call in a try-catch block
- Added error toast notification ("Impossible de supprimer le document") when deletion fails

## Implementation Details

The delete action now properly handles async operations from the `onRemove` callback, catching any errors that may occur during the deletion process and displaying a user-friendly error message in French, consistent with the application's localization.

https://claude.ai/code/session_01AbqXpLS6vmqhyuN6QQyojH