### PR TITLE
Fix VAT breakdown derivation for Factur-X compliance (BR-CO-18)

### DIFF
--- a/backend/src/services/modules/e-invoices/services/invoice-converter.spec.ts
+++ b/backend/src/services/modules/e-invoices/services/invoice-converter.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "@jest/globals";
+import { convertInternalToEN16931, ResolvedEntities } from "./invoice-converter";
+import Invoices from "../../invoices/entities/invoices";
+import Clients from "#src/services/clients/entities/clients";
+import Contacts from "../../contacts/entities/contacts";
+import Articles from "../../articles/entities/articles";
+
+const buildResolvedEntities = (): ResolvedEntities => {
+  const self = {
+    company: {
+      name: "Proxima",
+      legal_name: "Proxima",
+      tax_number: "FR35527830681",
+      registration_number: "52783068100054",
+    },
+    address: {
+      address_line_1: "44 AVENUE DU LAC",
+      city: "FLOURENS",
+      zip: "31130",
+      country: "FR",
+    },
+    invoices: {},
+  } as unknown as Clients;
+
+  const client = {
+    id: "client-1",
+    business_name: "AGS NICE COTE D'AZUR",
+    business_registered_id: "384037701",
+    address: {
+      address_line_1: "ZI LE BROC",
+      city: "CARROS",
+      zip: "06510",
+      country: "FR",
+    },
+    invoices: {},
+  } as unknown as Contacts;
+
+  const articles = new Map<string, Articles>();
+  articles.set("article-1", {
+    id: "article-1",
+    name: "Service",
+  } as unknown as Articles);
+
+  return { self, client, supplier: client, articles };
+};
+
+const buildInvoice = (
+  total: Partial<Invoices["total"]>
+): Invoices =>
+  ({
+    type: "invoices",
+    reference: "FAC/2025/01846",
+    name: "FAC/2025/01846",
+    currency: "EUR",
+    emit_date: "2025-06-30",
+    payment_information: { mode: "" },
+    content: [
+      {
+        article: "article-1",
+        name: "Reset password",
+        quantity: 1,
+        unit_price: 82,
+        tva: "20",
+        discount: { mode: "amount", value: 0 },
+      },
+    ],
+    total: {
+      total: 82,
+      total_with_taxes: 98.4,
+      ...total,
+    },
+  } as unknown as Invoices);
+
+describe("convertInternalToEN16931 VAT breakdown", () => {
+  test("uses the precomputed VAT breakdown when available", () => {
+    const result = convertInternalToEN16931(
+      buildInvoice({
+        vat_breakdown: [
+          { tva: "20", taxable_amount: 82, tax_amount: 16.4 },
+        ],
+      }),
+      buildResolvedEntities()
+    );
+
+    expect(result.vat_break_down).toHaveLength(1);
+    expect(result.vat_break_down[0].vat_category_code).toBe("S");
+    expect(result.vat_break_down[0].vat_category_rate).toBe("20");
+    expect(result.vat_break_down[0].vat_category_taxable_amount).toBe("82");
+    expect(result.vat_break_down[0].vat_category_tax_amount).toBe("16.4");
+  });
+
+  test("derives the VAT breakdown from lines when it is missing (BR-CO-18)", () => {
+    const result = convertInternalToEN16931(
+      buildInvoice({ vat_breakdown: undefined }),
+      buildResolvedEntities()
+    );
+
+    // Must not be empty, otherwise Factur-X fails BR-CO-18 (BG-23).
+    expect(result.vat_break_down.length).toBeGreaterThan(0);
+    expect(result.vat_break_down[0].vat_category_code).toBe("S");
+    expect(result.vat_break_down[0].vat_category_rate).toBe("20");
+    expect(result.vat_break_down[0].vat_category_taxable_amount).toBe("82.00");
+    expect(result.vat_break_down[0].vat_category_tax_amount).toBe("16.40");
+    // Document totals stay consistent with the derived breakdown.
+    expect(result.totals.total_without_vat).toBe("82");
+    expect(result.totals.total_with_vat).toBe("98.4");
+  });
+
+  test("derives the VAT breakdown when the precomputed one is an empty array", () => {
+    const result = convertInternalToEN16931(
+      buildInvoice({ vat_breakdown: [] }),
+      buildResolvedEntities()
+    );
+
+    expect(result.vat_break_down.length).toBeGreaterThan(0);
+    expect(result.vat_break_down[0].vat_category_code).toBe("S");
+    expect(result.vat_break_down[0].vat_category_rate).toBe("20");
+  });
+});

--- a/backend/src/services/modules/e-invoices/services/invoice-converter.ts
+++ b/backend/src/services/modules/e-invoices/services/invoice-converter.ts
@@ -735,17 +735,74 @@ export function convertInternalToEN16931(
     }
   }
 
-  // Calculate totals from precomputed
-  const totalWithoutVat = invoice.total?.vat_breakdown
-    ? invoice.total.vat_breakdown.reduce(
-        (sum, vb) => sum + vb.taxable_amount,
-        0
-      )
-    : sumOfLineNetAmounts - documentAllowanceAmount + documentChargeAmount;
+  // Fallback: if the precomputed VAT breakdown is missing or empty (e.g. legacy
+  // or stale totals), derive it from the invoice lines and document-level
+  // allowances/charges. Without this, the generated document has no VAT
+  // breakdown group and Factur-X validation fails with BR-CO-18 (BG-23).
+  if (vatBreakDown.length === 0 && lines.length > 0) {
+    const derived: { [key: string]: EN16931VatBreakDown } = {};
 
-  const totalVat = invoice.total?.vat_breakdown
-    ? invoice.total.vat_breakdown.reduce((sum, vb) => sum + vb.tax_amount, 0)
-    : 0;
+    const addToGroup = (
+      categoryCode: string,
+      rate: number,
+      taxableDelta: number
+    ) => {
+      const key = `${categoryCode}:${rate}`;
+      if (!derived[key]) {
+        derived[key] = {
+          vat_category_taxable_amount: "0",
+          vat_category_tax_amount: "0",
+          vat_category_code: categoryCode,
+          vat_category_rate: rate.toString(),
+        };
+      }
+      const taxable =
+        parseFloat(derived[key].vat_category_taxable_amount) + taxableDelta;
+      derived[key].vat_category_taxable_amount = taxable.toFixed(2);
+      derived[key].vat_category_tax_amount = (taxable * (rate / 100)).toFixed(2);
+    };
+
+    for (const line of lines) {
+      addToGroup(
+        line.vat_information.invoiced_item_vat_category_code,
+        parseFloat(line.vat_information.invoiced_item_vat_rate),
+        parseFloat(line.net_amount)
+      );
+    }
+
+    for (const allowance of documentAllowances) {
+      addToGroup(
+        allowance.vat_category_code,
+        parseFloat(allowance.vat_rate),
+        -parseFloat(allowance.amount)
+      );
+    }
+
+    for (const charge of documentCharges) {
+      addToGroup(
+        charge.vat_category_code,
+        parseFloat(charge.vat_rate),
+        parseFloat(charge.amount)
+      );
+    }
+
+    vatBreakDown.push(...Object.values(derived));
+  }
+
+  // Calculate totals from the final VAT breakdown (precomputed or derived) so
+  // the document totals stay consistent with the breakdown groups.
+  const totalWithoutVat =
+    vatBreakDown.length > 0
+      ? vatBreakDown.reduce(
+          (sum, vb) => sum + parseFloat(vb.vat_category_taxable_amount),
+          0
+        )
+      : sumOfLineNetAmounts - documentAllowanceAmount + documentChargeAmount;
+
+  const totalVat = vatBreakDown.reduce(
+    (sum, vb) => sum + parseFloat(vb.vat_category_tax_amount),
+    0
+  );
 
   // Add global VAT codes if there's only one breakdown entry
   let globalVatCategoryCode: string | undefined = undefined;


### PR DESCRIPTION
## Summary

This PR fixes e-invoice generation to ensure VAT breakdown groups are always present, preventing Factur-X validation failures when precomputed VAT breakdowns are missing or empty.

## Changes

- **Added comprehensive test coverage** (`invoice-converter.spec.ts`):
  - Tests for using precomputed VAT breakdown when available
  - Tests for deriving VAT breakdown from invoice lines when missing
  - Tests for handling empty precomputed VAT breakdown arrays
  - Validates that document totals remain consistent with derived breakdowns

- **Implemented VAT breakdown fallback logic** (`invoice-converter.ts`):
  - When `vatBreakDown` is empty and invoice lines exist, derive the breakdown from:
    - Individual line items (grouped by VAT category and rate)
    - Document-level allowances (with negative amounts)
    - Document-level charges (with positive amounts)
  - Groups line items by VAT category code and rate, accumulating taxable amounts and calculating tax amounts
  - Ensures document totals (`totalWithoutVat`, `totalVat`) are calculated from the final VAT breakdown (precomputed or derived) for consistency
  - Fixes Factur-X validation error BR-CO-18 (BG-23) which requires at least one VAT breakdown group

## Implementation Details

- The fallback derivation only triggers when `vatBreakDown.length === 0 && lines.length > 0`, preserving precomputed breakdowns when available
- Uses a keyed object (`categoryCode:rate`) to group line items, allowances, and charges by their VAT characteristics
- Maintains decimal precision with `.toFixed(2)` formatting for all monetary amounts
- Document totals are now always derived from the final VAT breakdown, ensuring consistency between breakdown groups and document-level totals

https://claude.ai/code/session_015MY4shwutbndEKK68VtD4V