### PR TITLE
ci: run backend linter and tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+# Run the backend linter and test suite on every pull request so regressions
+# are caught before merging (the deploy workflows only run on push to main).
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    name: Backend lint & tests
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: linventaire
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Remove root ESLint config
+        working-directory: ./
+        run: rm -f .eslintrc.json
+
+      - name: Install shared dependencies
+        working-directory: ./shared
+        run: npm install
+
+      - name: Build shared library
+        working-directory: ./shared
+        run: npm run build
+
+      - name: Install dependencies
+        working-directory: ./backend
+        run: npm install
+
+      - name: Run linter
+        working-directory: ./backend
+        run: npm run linter
+
+      - name: Run tests
+        working-directory: ./backend
+        run: npm run test


### PR DESCRIPTION
## Problem

The existing workflows (`deploy-backend.yml`, `deploy-frontend.yml`, `deploy-docker.yml`) only run on `push` to `main`. The lint/test job that already exists in `deploy-backend.yml` is therefore **never triggered on pull requests**, so regressions aren't caught before merge.

## Change

Adds a dedicated `.github/workflows/ci.yml` that runs on every `pull_request` (and via manual `workflow_dispatch`):

- **Backend lint & tests** job on `ubuntu-latest`, Node 20
- Spins up a `postgres:16` service (db `linventaire`, user/pass `postgres/postgres`) matching `backend/config/default.json`, so the server-backed Jest suite (`CREATE_SERVER=1 NODE_ENV=tests`) can connect. The app creates its own schema (`CREATE DATABASE` / `CREATE TABLE IF NOT EXISTS`) on boot.
- Mirrors the proven steps from the existing `deploy-backend.yml` lint job: remove the root ESLint config, build the `shared` lib, install backend deps, run `npm run linter`, run `npm run test`.

## Validation

Ran the full pipeline locally against a real Postgres 16:
- `npm run linter` → passes (exit 0) after removing the root `.eslintrc.json`.
- `npm run test` → **34 passed, 1 failed**.

The single failure is **pre-existing on `main`**, not introduced here: `rest-searchable.spec.ts › expandNumericPrefixes`. Commit `b3cb6b5` added the function with `MIN_PREFIX_LENGTH = 3` plus its test; a later commit `690d24a` ("fix: migration of references for search") changed it to `1` without updating the test. This PR intentionally only adds CI — the failing test is surfaced (which is the point of CI) and should be resolved in a follow-up once the intended behaviour is confirmed.

https://claude.ai/code/session_01FSLjrQwWCeLBUNbjRQR1zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSLjrQwWCeLBUNbjRQR1zg)_