### PR TITLE
Add email link pre-validation for document signing

### DIFF
--- a/backend/src/services/modules/signing-sessions/adapters/internal/internal.ts
+++ b/backend/src/services/modules/signing-sessions/adapters/internal/internal.ts
@@ -392,6 +392,35 @@ export default class InternalAdapter implements DocumentSignerInterface {
     }
   }
 
+  /**
+   * Marks the e-sign session as verified without an email code. Used when the
+   * signer proves mailbox ownership by opening the secret link from their email.
+   * The expiry is refreshed so the pre-validated link keeps working and can be
+   * reused as many times as needed until the document is actually signed.
+   */
+  async markVerified(token: string): Promise<void> {
+    const db = await Framework.Db.getService();
+    const session = await db.selectOne<ESignSessions>(
+      {} as Context,
+      ESignSessionsDefinition.name,
+      { token }
+    );
+
+    if (!session) {
+      throw new Error("Invalid token");
+    }
+
+    await db.update<ESignSessions>(
+      {} as Context,
+      ESignSessionsDefinition.name,
+      { token },
+      {
+        is_verified: true,
+        expires_at: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      } as Partial<ESignSessions>
+    );
+  }
+
   async verifyCode(token: string, code: string): Promise<boolean> {
     const db = await Framework.Db.getService();
     const session = await this.getSigningSessionByToken(token);

--- a/backend/src/services/modules/signing-sessions/entities/signing-session.ts
+++ b/backend/src/services/modules/signing-sessions/entities/signing-session.ts
@@ -26,6 +26,10 @@ export class SigningSessions extends RestEntity {
   signing_url = "string";
   reason = "string";
   recipient_token = "string";
+  // Secret token embedded in the email signing link. When the recipient opens
+  // the link from their mailbox, presenting this token proves control of that
+  // mailbox and pre-validates the session, so the email OTP step is skipped.
+  access_token = "string";
   expired = false;
 }
 
@@ -44,6 +48,7 @@ export const SigningSessionsDefinition: RestTableDefinition = {
     document_url: "TEXT",
     signing_url: "TEXT",
     recipient_token: "VARCHAR(64)",
+    access_token: "VARCHAR(128)",
     expired: "BOOLEAN",
   },
   pk: ["invoice_id", "recipient_email", "id"],

--- a/backend/src/services/modules/signing-sessions/routes.ts
+++ b/backend/src/services/modules/signing-sessions/routes.ts
@@ -2,6 +2,7 @@ import platform from "#src/platform/index";
 import Services from "#src/services/index";
 import { Ctx } from "#src/services/utils";
 import config from "config";
+import crypto from "crypto";
 import { Router } from "express";
 import { checkRole } from "../../common";
 import Invoices, {
@@ -279,7 +280,7 @@ export default (router: Router) => {
     }
 
     if (signingSession.state === "sent" || signingSession.state === "signed") {
-      return res.json(signingSession);
+      return res.json(cleanSigningSession(signingSession));
     }
 
     const invoice = signingSession.invoice_snapshot as unknown as Invoices;
@@ -354,7 +355,7 @@ export default (router: Router) => {
     // Save optional lines selected by the signer
     await saveInvoiceOptions(ctx, invoice, options, altReference);
 
-    res.json(signingSession);
+    res.json(cleanSigningSession(signingSession));
   });
 
   router.post("/:id/view", async (req, res) => {
@@ -382,7 +383,7 @@ export default (router: Router) => {
       signingSession.state === "signed" ||
       signingSession.state === "cancelled"
     ) {
-      return res.json(signingSession);
+      return res.json(cleanSigningSession(signingSession));
     }
 
     updateSigningSession(ctx, {
@@ -421,7 +422,7 @@ export default (router: Router) => {
       signingSession.state === "signed" ||
       signingSession.state === "cancelled"
     ) {
-      return res.json(signingSession);
+      return res.json(cleanSigningSession(signingSession));
     }
 
     // TODO we should check if any recipients have signed !!!
@@ -442,7 +443,7 @@ export default (router: Router) => {
     // Create timeline event
     await createSigningTimelineEvent(ctx, invoice, signingSession);
 
-    res.json(signingSession);
+    res.json(cleanSigningSession(signingSession));
   });
 
   router.post("/:id/cancel", async (req, res) => {
@@ -469,13 +470,13 @@ export default (router: Router) => {
       signingSession.state === "signed" ||
       signingSession.state === "cancelled"
     ) {
-      return res.json(signingSession);
+      return res.json(cleanSigningSession(signingSession));
     }
 
     const invoice = signingSession.invoice_snapshot as unknown as Invoices;
 
     if (!(invoice?.type === "quotes" || invoice?.type === "credit_notes")) {
-      return res.json(signingSession);
+      return res.json(cleanSigningSession(signingSession));
     }
 
     await cancelSigningSessions(ctx, invoice);
@@ -533,7 +534,7 @@ export default (router: Router) => {
       reactions: [],
     });
 
-    res.json(signingSession);
+    res.json(cleanSigningSession(signingSession));
   });
 
   router.get("/:id/download", async (req, res) => {
@@ -644,42 +645,12 @@ export default (router: Router) => {
       >;
 
       // Get or create the e_sign_session
-      let eSignSession = await adapter.getSigningSessionBySigningSessionId(
-        signingSession.id
+      const { eSignSession } = await ensureESignSession(
+        ctx,
+        signingSession,
+        adapter,
+        invoice
       );
-
-      if (!eSignSession) {
-        // Create the e_sign_session if it doesn't exist yet
-        const documentToSign = await adapter.addDocumentToSign({
-          signingSessionId: signingSession.id,
-          title: invoice.reference,
-          reference: signingSession.id,
-          recipients: [
-            {
-              name: "Signer",
-              email: signingSession.recipient_email,
-            },
-          ],
-          subject: "",
-          message: "",
-          redirectUrl: config
-            .get<string>("signature.webhook.signed")
-            .replace(":signing-session", signingSession.id),
-        });
-
-        // Update signing session with external_id and token
-        signingSession = await updateSigningSession(ctx, {
-          ...signingSession,
-          external_id: documentToSign.id,
-          recipient_token: documentToSign.recipients[0].token,
-          state: "sent",
-        });
-
-        // Get the newly created e_sign_session
-        eSignSession = await adapter.getSigningSessionBySigningSessionId(
-          signingSession.id
-        );
-      }
 
       if (!eSignSession) {
         return res
@@ -709,13 +680,20 @@ export default (router: Router) => {
       return res.status(400).json({ error: "Internal signing not enabled" });
     }
 
-    const { code, signatureBase64, options, metadata, reference } = req.body;
+    const { code, accessToken, signatureBase64, options, metadata, reference } =
+      req.body;
 
-    if (!code || !signatureBase64) {
-      return res.status(400).json({ error: "Code and signature required" });
+    if (!signatureBase64) {
+      return res.status(400).json({ error: "Signature required" });
     }
 
-    const signingSession = await db.selectOne<SigningSessions>(
+    if (!code && !accessToken) {
+      return res
+        .status(400)
+        .json({ error: "Verification code or access token required" });
+    }
+
+    let signingSession = await db.selectOne<SigningSessions>(
       ctx,
       SigningSessionsDefinition.name,
       { id: req.params.id },
@@ -734,26 +712,52 @@ export default (router: Router) => {
       return res.status(400).json({ error: "Document already signed" });
     }
 
+    const invoice = signingSession.invoice_snapshot as unknown as Invoices;
+
+    if (!invoice) {
+      return res.status(400).json({ error: "Invoice not found" });
+    }
+
+    if (invoice.type === "invoices") {
+      return res.status(400).json({ error: "Cannot sign invoice" });
+    }
+
     try {
       const adapter = Services.SignatureSessions.documentSigner as InstanceType<
         typeof InternalAdapter
       >;
 
-      // Get the e_sign_session
-      const eSignSession = await adapter.getSigningSessionBySigningSessionId(
-        signingSession.id
+      // Get or lazily create the e_sign_session (a signer who pre-validates via
+      // the email link may never have gone through the request-verification step)
+      const ensured = await ensureESignSession(
+        ctx,
+        signingSession,
+        adapter,
+        invoice
       );
+      signingSession = ensured.signingSession;
+      const eSignSession = ensured.eSignSession;
       if (!eSignSession) {
         return res.status(404).json({ error: "Internal session not found" });
       }
 
-      // Verify the code
-      const isValid = await adapter.verifyCode(eSignSession.token, code);
-      if (!isValid) {
-        return res.status(400).json({ error: "Code invalide ou expiré" });
-      }
+      // Two ways to prove identity:
+      //  - a valid access token from the email link pre-validates the session
+      //    (proof of mailbox ownership) and skips the email code entirely;
+      //  - otherwise fall back to the email verification code (OTP).
+      const hasValidAccessToken = isValidAccessToken(
+        signingSession.access_token,
+        accessToken
+      );
 
-      const invoice = signingSession.invoice_snapshot as unknown as Invoices;
+      if (hasValidAccessToken) {
+        await adapter.markVerified(eSignSession.token);
+      } else {
+        const isValid = await adapter.verifyCode(eSignSession.token, code);
+        if (!isValid) {
+          return res.status(400).json({ error: "Code invalide ou expiré" });
+        }
+      }
 
       // Save optional lines selected by the signer BEFORE generating PDF
       await saveInvoiceOptions(ctx, invoice, options, reference);
@@ -831,5 +835,72 @@ const cleanSigningSession = (session: SigningSessions) => {
     (session.invoice_snapshot as unknown as Invoices).name = "";
   }
 
+  // Never expose the secret access token through the public API: the legitimate
+  // recipient already holds it in their email link, and returning it here would
+  // let anyone who merely knows the session id bypass the verification step.
+  if (session.access_token) {
+    session.access_token = "";
+  }
+
   return session;
+};
+
+/**
+ * Constant-time comparison of the access token carried in the email link
+ * against the one stored on the signing session.
+ */
+const isValidAccessToken = (stored?: string, provided?: string): boolean => {
+  if (!stored || !provided) return false;
+  const storedBuffer = Buffer.from(stored);
+  const providedBuffer = Buffer.from(provided);
+  if (storedBuffer.length !== providedBuffer.length) return false;
+  return crypto.timingSafeEqual(storedBuffer, providedBuffer);
+};
+
+/**
+ * Ensures the internal e_sign_session backing this signing session exists,
+ * lazily creating it (and persisting external_id / recipient_token) if needed.
+ * Returns the resolved e_sign_session and the possibly-updated signing session.
+ */
+const ensureESignSession = async (
+  ctx: any,
+  signingSession: SigningSessions,
+  adapter: InstanceType<typeof InternalAdapter>,
+  invoice: Invoices
+) => {
+  let eSignSession = await adapter.getSigningSessionBySigningSessionId(
+    signingSession.id
+  );
+
+  if (!eSignSession) {
+    const documentToSign = await adapter.addDocumentToSign({
+      signingSessionId: signingSession.id,
+      title: invoice.reference,
+      reference: signingSession.id,
+      recipients: [
+        {
+          name: "Signer",
+          email: signingSession.recipient_email,
+        },
+      ],
+      subject: "",
+      message: "",
+      redirectUrl: config
+        .get<string>("signature.webhook.signed")
+        .replace(":signing-session", signingSession.id),
+    });
+
+    signingSession = await updateSigningSession(ctx, {
+      ...signingSession,
+      external_id: documentToSign.id,
+      recipient_token: documentToSign.recipients[0].token,
+      state: "sent",
+    });
+
+    eSignSession = await adapter.getSigningSessionBySigningSessionId(
+      signingSession.id
+    );
+  }
+
+  return { eSignSession, signingSession };
 };

--- a/backend/src/services/modules/signing-sessions/services/create.ts
+++ b/backend/src/services/modules/signing-sessions/services/create.ts
@@ -1,5 +1,6 @@
 import { id } from "#src/platform/db/utils";
 import { create } from "#src/services/rest/services/rest";
+import crypto from "crypto";
 import platform from "../../../../platform";
 import Invoices from "../../invoices/entities/invoices";
 import {
@@ -28,6 +29,10 @@ export const createSigningSession = async (
     state: "created",
     document_url: null,
     signing_url: null,
+    // High-entropy secret carried in the email signing link. Knowing it proves
+    // the recipient opened the link from their own mailbox, which lets us
+    // pre-validate the session and skip the email verification code.
+    access_token: crypto.randomBytes(32).toString("hex"),
   };
 
   const createdSigningSession = await create<SigningSessions>(

--- a/backend/src/services/modules/signing-sessions/services/utils.ts
+++ b/backend/src/services/modules/signing-sessions/services/utils.ts
@@ -73,6 +73,15 @@ export const generateEmailMessageToRecipient = async (
     buttonHref = config
       .get<string>("signature.webhook.to_sign")
       .replace(":signing-session", signingSession?.id);
+
+    // Append the secret access token so that opening the link pre-validates the
+    // signing session (proof of mailbox ownership) and lets the signer skip the
+    // email verification code, which some recipients never receive.
+    if (signingSession.access_token) {
+      buttonHref +=
+        (buttonHref.includes("?") ? "&" : "?") +
+        `token=${encodeURIComponent(signingSession.access_token)}`;
+    }
   }
 
   if (signingSession && action === "signed") {

--- a/frontend/src/views/client/modules/signing-session/components/document-layout.tsx
+++ b/frontend/src/views/client/modules/signing-session/components/document-layout.tsx
@@ -40,6 +40,7 @@ interface DocumentLayoutProps {
   actions: ReactNode;
   imageWhenNoDocument?: boolean;
   onSigned?: () => void;
+  signToken?: string;
 }
 
 // Error display when session has an error
@@ -210,6 +211,7 @@ export const DocumentLayout = ({
   actions,
   imageWhenNoDocument = false,
   onSigned,
+  signToken,
 }: DocumentLayoutProps) => {
   if (isLoading || !signingSession) {
     return <DocumentLoading />;
@@ -290,6 +292,7 @@ export const DocumentLayout = ({
                 options={options}
                 onOptionChange={handleOptionChange}
                 onSigned={onSigned || (() => {})}
+                signToken={signToken}
               />
             </div>
           </div>
@@ -355,6 +358,7 @@ export const DocumentLayout = ({
                     options={options}
                     onOptionChange={handleOptionChange}
                     onSigned={onSigned || (() => {})}
+                    signToken={signToken}
                   />
                 ) : (
                   <div className="p-4 flex flex-col h-full">

--- a/frontend/src/views/client/modules/signing-session/components/internal-signature-form.tsx
+++ b/frontend/src/views/client/modules/signing-session/components/internal-signature-form.tsx
@@ -19,6 +19,9 @@ interface InternalSignatureFormProps {
   options: (InvoiceLine & { _index: number })[];
   onOptionChange: (optionId: string, value: boolean) => void;
   onSigned: () => void;
+  // Secret token from the email link. When set, the session is pre-validated and
+  // the signer signs directly without entering an email verification code.
+  signToken?: string;
 }
 
 type Step = "form" | "otp" | "success";
@@ -28,6 +31,7 @@ export const InternalSignatureForm = ({
   options,
   onOptionChange,
   onSigned,
+  signToken,
 }: InternalSignatureFormProps) => {
   const [step, setStep] = useState<Step>("form");
   const [email, setEmail] = useState(signingSession.recipient_email || "");
@@ -67,7 +71,44 @@ export const InternalSignatureForm = ({
     }
   }, [step, resendTimer]);
 
-  // Request OTP and move to verification step
+  // Call verify-and-sign with either the email link token or the email OTP code.
+  const signDocument = async (
+    signatureBase64: string,
+    auth: { code?: string; accessToken?: string },
+  ) => {
+    if (signingSession.state === "signed") {
+      toast.error("Ce document a déjà été signé");
+      return;
+    }
+
+    const response = await fetchServer(
+      `/api/signing-sessions/v1/${signingSession.id}/verify-and-sign`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...auth,
+          signatureBase64,
+          options,
+          reference: altReference,
+          metadata: {
+            userAgent: navigator.userAgent,
+          },
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const data = await response.json();
+      throw new Error(data.error || "Code invalide");
+    }
+
+    setStep("success");
+    toast.success("Document signé avec succès !");
+    onSigned();
+  };
+
+  // Submit the form: sign directly when pre-validated by the email link token,
+  // otherwise request an email verification code (OTP) and move to that step.
   const handleSubmitForm = async () => {
     if (!hasReadDocument) {
       toast.error("Veuillez confirmer avoir lu le document");
@@ -85,7 +126,19 @@ export const InternalSignatureForm = ({
       const signatureBase64 = sigCanvas.current!.toDataURL();
       setSignatureData(signatureBase64);
 
-      // Call the backend to send the verification code
+      // Pre-validated through the email link: sign directly, no code needed.
+      if (signToken) {
+        try {
+          await signDocument(signatureBase64, { accessToken: signToken });
+          return;
+        } catch (tokenError) {
+          // The link token was rejected (tampered/stale). Rather than leaving the
+          // signer stuck, fall back to the email verification code flow below.
+          console.error("Token sign failed, falling back to OTP:", tokenError);
+        }
+      }
+
+      // Otherwise, ask the backend to send the verification code.
       const response = await fetchServer(
         `/api/signing-sessions/v1/${signingSession.id}/request-verification`,
         {
@@ -103,8 +156,12 @@ export const InternalSignatureForm = ({
       setCanResend(false);
       toast.success("Un code de vérification a été envoyé à votre email");
     } catch (error: any) {
-      toast.error("Erreur lors de l'envoi du code de vérification");
-      console.error("Request verification error:", error);
+      toast.error(
+        signToken
+          ? error.message || "Erreur lors de la signature"
+          : "Erreur lors de l'envoi du code de vérification",
+      );
+      console.error("Submit signature error:", error);
     } finally {
       setIsLoading(false);
     }
@@ -122,39 +179,9 @@ export const InternalSignatureForm = ({
       return;
     }
 
-    // Check if already signed
-    if (signingSession.state === "signed") {
-      toast.error("Ce document a déjà été signé");
-      return;
-    }
-
     setOtpLoading(true);
     try {
-      // Verify code and sign in one call
-      const response = await fetchServer(
-        `/api/signing-sessions/v1/${signingSession.id}/verify-and-sign`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            code,
-            signatureBase64: signatureData,
-            options,
-            reference: altReference,
-            metadata: {
-              userAgent: navigator.userAgent,
-            },
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || "Code invalide");
-      }
-
-      setStep("success");
-      toast.success("Document signé avec succès !");
-      onSigned();
+      await signDocument(signatureData, { code });
     } catch (error: any) {
       toast.error(
         error.message || "Code invalide ou erreur lors de la signature",
@@ -359,9 +386,11 @@ export const InternalSignatureForm = ({
                   disabled
                   className="w-full"
                 />
-                <p className="text-xs text-gray-500 mt-1">
-                  Un code de vérification sera envoyé à cette adresse
-                </p>
+                {!signToken && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    Un code de vérification sera envoyé à cette adresse
+                  </p>
+                )}
               </div>
 
               {/* Signature canvas */}
@@ -423,7 +452,11 @@ export const InternalSignatureForm = ({
                 disabled={isLoading || !hasReadDocument || !hasSignature}
                 icon={(p) => <CheckIcon {...p} />}
               >
-                {isLoading ? "Envoi en cours..." : "Signer le document"}
+                {isLoading
+                  ? signToken
+                    ? "Signature en cours..."
+                    : "Envoi en cours..."
+                  : "Signer le document"}
               </Button>
             </div>
           </>
@@ -486,9 +519,11 @@ export const InternalSignatureForm = ({
               disabled
               className="w-full"
             />
-            <p className="text-xs text-gray-500 mt-1">
-              Un code de vérification sera envoyé à cette adresse
-            </p>
+            {!signToken && (
+              <p className="text-xs text-gray-500 mt-1">
+                Un code de vérification sera envoyé à cette adresse
+              </p>
+            )}
           </div>
 
           {/* Signature canvas */}
@@ -550,7 +585,11 @@ export const InternalSignatureForm = ({
             disabled={isLoading || !hasReadDocument || !hasSignature}
             icon={(p) => <CheckIcon {...p} />}
           >
-            {isLoading ? "Envoi en cours..." : "Signer le document"}
+            {isLoading
+              ? signToken
+                ? "Signature en cours..."
+                : "Envoi en cours..."
+              : "Signer le document"}
           </Button>
         </div>
       </div>

--- a/frontend/src/views/client/modules/signing-session/index.tsx
+++ b/frontend/src/views/client/modules/signing-session/index.tsx
@@ -9,7 +9,7 @@ import { CheckIcon, XCircleIcon } from "@heroicons/react/16/solid";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { DocumentLayout } from "./components/document-layout";
 import { useMobile } from "./hooks/use-mobile";
 import Env from "@/config/environment";
@@ -18,6 +18,10 @@ export const SigningSessionPage = () => {
   const navigate = useNavigate();
 
   const { session: sessionID } = useParams();
+  // Secret token carried in the email signing link. When present it pre-validates
+  // the session so the signer can sign without receiving an email code (OTP).
+  const [searchParams] = useSearchParams();
+  const signToken = searchParams.get("token") ?? undefined;
   const {
     signingSession,
     viewSigningSession,
@@ -236,6 +240,7 @@ export const SigningSessionPage = () => {
       onOptionChange={handleOptionChange}
       actions={<ActionButtons isMobile={isMobile} />}
       onSigned={handleInternalSigned}
+      signToken={signToken}
     />
   );
 };


### PR DESCRIPTION
## Summary

Implement a secure email link pre-validation mechanism for document signing that allows recipients to skip the email verification code (OTP) step by opening a secret token embedded in their signing link. This improves UX for recipients who don't receive or lose the OTP email while maintaining security through constant-time token comparison and mailbox ownership proof.

## Key Changes

**Backend:**
- Add `access_token` field to `SigningSessions` entity - a high-entropy secret generated during session creation and embedded in the email signing link
- Implement `isValidAccessToken()` helper using `crypto.timingSafeEqual()` for constant-time comparison to prevent timing attacks
- Add `markVerified()` method to `InternalAdapter` to mark e-sign sessions as verified when the access token is presented (refreshes expiry to keep link valid)
- Extract e-sign session creation logic into `ensureESignSession()` helper function to support lazy creation when signers pre-validate via email link
- Update `/verify-and-sign` endpoint to accept either `code` (OTP) or `accessToken` (email link token) for authentication
- Add validation to prevent signing of invoices (only quotes and credit notes allowed)
- Refactor `cleanSigningSession()` to redact the `access_token` from API responses (never expose the secret through public API)
- Update email message generation to append the access token as a query parameter to the signing URL

**Frontend:**
- Add `signToken` prop to `InternalSignatureForm` component to receive the pre-validation token from the email link
- Implement fallback logic: attempt direct signing with the email link token first; if it fails (tampered/stale), fall back to OTP flow
- Extract signature submission logic into `signDocument()` helper to support both token and OTP authentication paths
- Update UI messaging to reflect the current authentication method ("Signature en cours..." vs "Envoi en cours...")
- Hide OTP-related messaging when pre-validated via email link
- Parse `token` query parameter from URL in signing session page and pass it through component hierarchy

## Implementation Details

- The access token is a cryptographically random string generated at session creation time
- Email links include the token as a query parameter: `?token=<encoded-secret>`
- Token validation uses `crypto.timingSafeEqual()` to prevent timing-based attacks
- When a valid token is presented, the e-sign session is marked verified and its expiry is refreshed (30 days), allowing the link to be reused
- The token is never returned in API responses to prevent leakage if someone knows the session ID
- Graceful fallback to OTP if the token is invalid/expired, ensuring signers aren't locked out
- Only quotes and credit notes support this flow; invoices cannot be signed via this mechanism

https://claude.ai/code/session_01N7q8g6SphfnBC7BMUTLRT9