### PR TITLE
feat(invoices): surface quote/invoice email send failures

### DIFF
--- a/backend/src/platform/push-email/index.ts
+++ b/backend/src/platform/push-email/index.ts
@@ -56,7 +56,7 @@ export default class PushEMail implements PlatformService {
       attachments?: EmailAttachment[];
     } = {},
     smtp?: SmtpOptions
-  ) {
+  ): Promise<boolean> {
     const language = platform.I18n.getLanguage(context);
     options.subject = options.subject || "New notification from L'Inventaire";
     let built = { html: "", text: "" };
@@ -73,7 +73,7 @@ export default class PushEMail implements PlatformService {
     } catch (e: any) {
       platform.LoggerDb.get("push-email").error(context, e);
       captureException(e);
-      return;
+      return false;
     }
 
     // Demo whitelisting system
@@ -141,8 +141,10 @@ export default class PushEMail implements PlatformService {
           "Email sent successfully via default adapter"
         );
       }
+      return true;
     } catch (err) {
       this.logger.error(context, "Failed to send email", err);
+      return false;
     }
   }
 }

--- a/backend/src/services/modules/comments/entities/comments.ts
+++ b/backend/src/services/modules/comments/entities/comments.ts
@@ -31,7 +31,9 @@ export type EventMetadatas =
     }
   | {
       event_type: "smtp_failed";
-      emails: string[];
+      emails: string[]; // Recipients that were rejected by the mail server
+      partial?: boolean; // true when some recipients did receive the email
+      sent_emails?: string[]; // Recipients that received the email (partial send)
     }
   | {
       event_type: "invoice_back_to_draft";

--- a/backend/src/services/modules/invoices/entities/invoices.ts
+++ b/backend/src/services/modules/invoices/entities/invoices.ts
@@ -6,6 +6,7 @@ import {
   InvoiceLine,
   InvoiceReminder,
   InvoiceReview,
+  InvoiceStateDetails,
   InvoiceTotal,
   PaymentComputed,
   Recipient,
@@ -48,6 +49,10 @@ export default class Invoices extends RestEntity {
     | "recurring"
     | "completed"
     | "closed" = "draft";
+
+  // Extra details about the current state (e.g. email send problems). This is
+  // reset automatically whenever the state changes (see the upsert-hook).
+  state_details?: InvoiceStateDetails | null = new InvoiceStateDetails();
 
   // For credit notes or supplier credit note: invoices refunded by this credit note
   from_rel_invoice = ["type:invoices"]; // Nullable
@@ -129,6 +134,7 @@ export {
   InvoiceLine,
   InvoiceReminder,
   InvoiceReview,
+  InvoiceStateDetails,
   InvoiceTotal,
   PaymentComputed,
   Recipient,

--- a/backend/src/services/modules/invoices/services/email-send-result.spec.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const update = jest.fn();
+const getService = jest.fn(async () => ({ update }));
+const createEvent = jest.fn();
+
+jest.mock("#src/platform/index", () => ({
+  __esModule: true,
+  default: { Db: { getService } },
+}));
+
+jest.mock("#src/services/index", () => ({
+  __esModule: true,
+  default: { Comments: { createEvent } },
+}));
+
+import { recordEmailSendResult } from "./email-send-result";
+
+const ctx = { client_id: "cl-1", id: "us-1", role: "USER" } as any;
+const invoice = (extra: any = {}) =>
+  ({ id: "inv-1", client_id: "cl-1", type: "quotes", ...extra } as any);
+
+describe("recordEmailSendResult", () => {
+  beforeEach(() => {
+    update.mockReset();
+    createEvent.mockReset();
+    getService.mockClear();
+  });
+
+  test("does nothing when everything was sent and no previous flag", async () => {
+    await recordEmailSendResult(ctx, invoice(), ["a@b.com"], []);
+    expect(createEvent).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("clears a previous flag once the send finally goes through", async () => {
+    await recordEmailSendResult(
+      ctx,
+      invoice({ state_details: { email_status: "failed" } }),
+      ["a@b.com"],
+      []
+    );
+    expect(createEvent).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][3] as any;
+    expect(payload.state_details.email_status).toBe("");
+    expect(payload.state_details.email_failed_recipients).toEqual([]);
+  });
+
+  test("records a TOTAL failure when every recipient was rejected", async () => {
+    await recordEmailSendResult(
+      ctx,
+      invoice(),
+      [],
+      ["a@b.com", "c@d.com"]
+    );
+
+    expect(createEvent).toHaveBeenCalledTimes(1);
+    const event = createEvent.mock.calls[0][1] as any;
+    expect(event.metadata.event_type).toBe("smtp_failed");
+    expect(event.metadata.partial).toBe(false);
+    expect(event.metadata.emails).toEqual(["a@b.com", "c@d.com"]);
+
+    const payload = update.mock.calls[0][3] as any;
+    expect(payload.state_details.email_status).toBe("failed");
+    expect(payload.state_details.email_failed_recipients).toEqual([
+      "a@b.com",
+      "c@d.com",
+    ]);
+  });
+
+  test("records a PARTIAL failure when some recipients received it", async () => {
+    await recordEmailSendResult(ctx, invoice(), ["a@b.com"], ["c@d.com"]);
+
+    expect(createEvent).toHaveBeenCalledTimes(1);
+    const event = createEvent.mock.calls[0][1] as any;
+    expect(event.metadata.event_type).toBe("smtp_failed");
+    expect(event.metadata.partial).toBe(true);
+    expect(event.metadata.emails).toEqual(["c@d.com"]);
+    expect(event.metadata.sent_emails).toEqual(["a@b.com"]);
+
+    const payload = update.mock.calls[0][3] as any;
+    expect(payload.state_details.email_status).toBe("partial");
+  });
+});

--- a/backend/src/services/modules/invoices/services/email-send-result.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.ts
@@ -1,0 +1,75 @@
+import Framework from "#src/platform/index";
+import Services from "#src/services/index";
+import { Context } from "#src/types";
+import Invoices, { InvoicesDefinition } from "../entities/invoices";
+
+/**
+ * Records the outcome of an email send attempt for a document.
+ *
+ * When at least one recipient was rejected by the mail server it:
+ *  - adds an event to the document timeline (and, through `createEvent`, a
+ *    notification for the subscribed users), differentiating a TOTAL failure
+ *    (no recipient received the document) from a PARTIAL send (some recipients
+ *    got it, some were rejected);
+ *  - flags the document with a "problème d'envoi" detail on `state_details` so a
+ *    tag can be shown on the document itself.
+ *
+ * When every recipient received the document it clears any previous
+ * send-problem flag (the send finally went through).
+ */
+export const recordEmailSendResult = async (
+  ctx: Context,
+  invoice: Invoices,
+  sentEmails: string[],
+  failedEmails: string[]
+) => {
+  const db = await Framework.Db.getService();
+
+  if (failedEmails.length === 0) {
+    // Everything went through: clear a previous send-problem flag if any.
+    if (invoice.state_details?.email_status) {
+      await db.update<Invoices>(
+        ctx,
+        InvoicesDefinition.name,
+        { id: invoice.id, client_id: invoice.client_id },
+        { state_details: { email_status: "", email_failed_recipients: [] } }
+      );
+    }
+    return;
+  }
+
+  const partial = sentEmails.length > 0;
+
+  // Timeline event + notification (createEvent fans out to notifyUsers because
+  // the metadata carries an event_type).
+  await Services.Comments.createEvent(ctx, {
+    client_id: invoice.client_id,
+    item_entity: "invoices",
+    item_id: invoice.id,
+    type: "event",
+    content: `Email delivery ${
+      partial ? "partially failed" : "failed"
+    } for ${failedEmails.join(", ")}`,
+    metadata: {
+      event_type: "smtp_failed",
+      emails: failedEmails,
+      partial,
+      sent_emails: sentEmails,
+    },
+    documents: [],
+    reactions: [],
+  });
+
+  // Flag the document so a "problème d'envoi" tag can be displayed.
+  await db.update<Invoices>(
+    ctx,
+    InvoicesDefinition.name,
+    { id: invoice.id, client_id: invoice.client_id },
+    {
+      state_details: {
+        email_status: partial ? "partial" : "failed",
+        email_failed_recipients: failedEmails,
+      },
+    }
+  );
+};

--- a/backend/src/services/modules/invoices/services/generate-pdf.tsx
+++ b/backend/src/services/modules/invoices/services/generate-pdf.tsx
@@ -21,6 +21,7 @@ import StockItems, {
 import Invoices from "../entities/invoices";
 import { computePricesFromInvoice } from "@shared/invoices";
 import { getPdf } from "./generate-pdf-components";
+import { recordEmailSendResult } from "./email-send-result";
 import { captureException } from "@sentry/node";
 
 export type PositionPdf = {
@@ -317,6 +318,8 @@ export const sendPdf = async (
   });
 
   // send emails
+  const sentEmails: string[] = [];
+  const failedEmails: string[] = [];
   for (const recipient of recipients) {
     const { message, subject, htmlLogo } =
       await generateEmailMessageToRecipient(
@@ -328,7 +331,7 @@ export const sendPdf = async (
           as: options.as,
         }
       );
-    await Framework.PushEMail.push(
+    const sent = await Framework.PushEMail.push(
       ctx,
       recipient,
       message,
@@ -340,7 +343,17 @@ export const sendPdf = async (
       },
       client.smtp
     );
+
+    if (sent) {
+      sentEmails.push(recipient);
+    } else {
+      failedEmails.push(recipient);
+    }
   }
+
+  // Record the outcome (timeline event + notification + document flag) so a
+  // failed send does not go unnoticed.
+  await recordEmailSendResult(ctx, document, sentEmails, failedEmails);
 };
 
 function stream2buffer(stream: NodeJS.ReadableStream): Promise<Buffer> {

--- a/backend/src/services/modules/invoices/triggers/upsert-hook.ts
+++ b/backend/src/services/modules/invoices/triggers/upsert-hook.ts
@@ -71,6 +71,20 @@ export const setUpsertHook = () =>
         updated.state = "draft";
       }
 
+      // state_details carries information tied to the CURRENT state (e.g. an
+      // email send problem). As soon as the state changes we reset it so the
+      // flag does not stick around on a state it no longer applies to.
+      if (
+        prev &&
+        prev.state !== updated.state &&
+        updated.state_details?.email_status
+      ) {
+        updated.state_details = {
+          email_status: "",
+          email_failed_recipients: [],
+        };
+      }
+
       updated.recipients = updated.recipients || [];
 
       // Fix content lines, make sure they have all required fields and no invisible fields still set after changing type for example

--- a/backend/src/services/modules/signing-sessions/index.ts
+++ b/backend/src/services/modules/signing-sessions/index.ts
@@ -138,6 +138,8 @@ export default class SigningSessionService
     if (!invoice) throw new Error("Invoice not found");
 
     const resultingSigningSessions: SigningSessions[] = [];
+    const sentEmails: string[] = [];
+    const failedEmails: string[] = [];
 
     for (const recipient of recipients) {
       if (!recipient) throw new Error("Recipient is wrong");
@@ -177,7 +179,7 @@ export default class SigningSessionService
         id: invoice.client_id,
       });
 
-      await platform.PushEMail.push(
+      const sent = await platform.PushEMail.push(
         ctx,
         recipient.email,
         message,
@@ -189,6 +191,12 @@ export default class SigningSessionService
         },
         client.smtp
       );
+
+      if (sent) {
+        sentEmails.push(recipient.email);
+      } else {
+        failedEmails.push(recipient.email);
+      }
     }
 
     // If we are sending the invoice again, we must expire other sessions
@@ -196,6 +204,10 @@ export default class SigningSessionService
       await expireOtherSigningSessions(ctx, resultingSigningSessions);
     }
 
-    return resultingSigningSessions;
+    return {
+      signingSessions: resultingSigningSessions,
+      sentEmails,
+      failedEmails,
+    };
   }
 }

--- a/backend/src/services/modules/signing-sessions/routes.ts
+++ b/backend/src/services/modules/signing-sessions/routes.ts
@@ -8,6 +8,7 @@ import { checkRole } from "../../common";
 import Invoices, {
   InvoiceLine,
   InvoicesDefinition,
+  Recipient,
 } from "../invoices/entities/invoices";
 
 import Clients, {
@@ -15,6 +16,7 @@ import Clients, {
 } from "#src/services/clients/entities/clients";
 import _ from "lodash";
 import { generatePdf } from "../invoices/services/generate-pdf";
+import { recordEmailSendResult } from "../invoices/services/email-send-result";
 import InternalAdapter from "./adapters/internal/internal";
 import {
   SigningSessions,
@@ -186,7 +188,7 @@ export default (router: Router) => {
       const ctx = Ctx.get(req)!.context;
       if (!req.body.recipients) throw new Error("Recipients are required");
 
-      const newSigningSessions =
+      const { signingSessions, sentEmails, failedEmails } =
         await Services.SignatureSessions.createSigningSessions(
           ctx,
           req.params.id,
@@ -207,25 +209,38 @@ export default (router: Router) => {
         throw new Error("Invoice not found");
       }
 
-      // Insérer l'événement dans la timeline
-      await Services.Comments.createEvent(ctx, {
-        client_id: invoice.client_id,
-        item_entity: "invoices",
-        item_id: invoice.id,
-        type: "event",
-        content: `Sent to ${req.body.recipients
-          .map((rec) => rec.email)
-          .join(", ")}`,
-        metadata: {
-          event_type:
-            invoice?.type === "quotes" ? "quote_sent" : "invoice_sent",
-          recipients: req.body.recipients,
-        },
-        documents: [],
-        reactions: [],
-      });
+      // Recipients that actually received the document (keep their signer/viewer
+      // role so the timeline keeps rendering them like before).
+      const sentRecipients = (req.body.recipients as Recipient[]).filter((rec) =>
+        sentEmails.includes(rec.email)
+      );
 
-      res.json(newSigningSessions);
+      // Insérer l'événement "envoyé" dans la timeline pour les destinataires
+      // qui ont bien reçu le document.
+      if (sentRecipients.length > 0) {
+        await Services.Comments.createEvent(ctx, {
+          client_id: invoice.client_id,
+          item_entity: "invoices",
+          item_id: invoice.id,
+          type: "event",
+          content: `Sent to ${sentRecipients
+            .map((rec) => rec.email)
+            .join(", ")}`,
+          metadata: {
+            event_type:
+              invoice?.type === "quotes" ? "quote_sent" : "invoice_sent",
+            recipients: sentRecipients,
+          },
+          documents: [],
+          reactions: [],
+        });
+      }
+
+      // Enregistrer le problème d'envoi (timeline + notification + tag sur le
+      // document) en différenciant l'échec total de l'envoi partiel.
+      await recordEmailSendResult(ctx, invoice, sentEmails, failedEmails);
+
+      res.json(signingSessions);
     }
   );
 

--- a/frontend/public/locales/fr.json
+++ b/frontend/public/locales/fr.json
@@ -295,6 +295,9 @@
     },
     "quote_refused": {
       "title": "Devis refusé par {{email}} pour la raison {{reason}}."
+    },
+    "smtp_failed": {
+      "title": "Échec de l'envoi du document."
     }
   },
   "timelines": {
@@ -310,7 +313,11 @@
         "content": "Devis <0>signé</0> par <1>{{email}}</1>. <2>Voir le document signé.</2>",
         "content_viewers": ", et aux signataires "
       },
-      "quote_refused": "Devis refusé par {{email}} pour la raison '{{reason}}'."
+      "quote_refused": "Devis refusé par {{email}} pour la raison '{{reason}}'.",
+      "smtp_failed": {
+        "content": "Échec de l'envoi du document à <0/>. Le mail n'a pas pu être délivré.",
+        "content_partial": "Le document n'a pas pu être envoyé à <0/>. Les autres destinataires l'ont bien reçu."
+      }
     }
   },
   "atoms": {

--- a/frontend/src/features/comments/types/types.ts
+++ b/frontend/src/features/comments/types/types.ts
@@ -21,7 +21,9 @@ export type EventMetadatas =
     }
   | {
       event_type: "smtp_failed";
-      emails: string[];
+      emails: string[]; // Recipients that were rejected by the mail server
+      partial?: boolean; // true when some recipients did receive the email
+      sent_emails?: string[]; // Recipients that received the email (partial send)
     }
   | {
       event_type: "invoice_back_to_draft";

--- a/frontend/src/features/invoices/configuration.tsx
+++ b/frontend/src/features/invoices/configuration.tsx
@@ -16,10 +16,11 @@ import { getRestApiClient } from "@features/utils/rest/hooks/use-rest";
 import {
   ArrowPathIcon,
   CheckIcon,
+  ExclamationCircleIcon,
   RectangleStackIcon,
 } from "@heroicons/react/16/solid";
 import { Column } from "@molecules/table/table";
-import { Badge } from "@radix-ui/themes";
+import { Badge, Tooltip } from "@radix-ui/themes";
 import {
   computePricesFromInvoice,
   isDeliveryLate,
@@ -248,12 +249,31 @@ export const InvoicesColumns: Column<Invoices>[] = [
     headClassName: "justify-end",
     orderBy: "state_order",
     render: (invoice) => (
-      <InvoiceStatus
-        size="sm"
-        readonly
-        value={invoice.state}
-        type={invoice.type}
-      />
+      <div className="flex flex-row items-center space-x-1">
+        {!!invoice.state_details?.email_status && (
+          <Tooltip
+            content={
+              invoice.state_details.email_status === "partial"
+                ? "Le document n'a pas pu être envoyé à certains destinataires : " +
+                  (invoice.state_details.email_failed_recipients || []).join(
+                    ", ",
+                  )
+                : "Le document n'a pas pu être envoyé : " +
+                  (invoice.state_details.email_failed_recipients || []).join(
+                    ", ",
+                  )
+            }
+          >
+            <ExclamationCircleIcon className="h-4 w-4 shrink-0 text-red-500" />
+          </Tooltip>
+        )}
+        <InvoiceStatus
+          size="sm"
+          readonly
+          value={invoice.state}
+          type={invoice.type}
+        />
+      </div>
     ),
   },
 ];

--- a/frontend/src/features/invoices/types/types.ts
+++ b/frontend/src/features/invoices/types/types.ts
@@ -30,6 +30,13 @@ export type Invoices = RestEntity & {
   // Invoices and Credit Notes: “draft”, “sent”, "closed"
   state: InvoicesState;
 
+  // Extra details tied to the current state (e.g. an email send problem).
+  // Reset by the backend whenever the state changes.
+  state_details?: {
+    email_status: "" | "partial" | "failed";
+    email_failed_recipients: string[];
+  } | null;
+
   // For credit notes or supplier credit note: invoices refunded by this credit note
   from_rel_invoice: string[]; // Nullable
   // For invoices or supplier invoice: quotes completed and transformed into this invoice

--- a/frontend/src/molecules/timeline/events.tsx
+++ b/frontend/src/molecules/timeline/events.tsx
@@ -55,6 +55,30 @@ export const Event = ({ id }: { id: string }) => {
     );
   }
 
+  if (metadata?.event_type === "smtp_failed") {
+    const failed = metadata.emails || [];
+    message = (
+      <Trans
+        t={t}
+        i18nKey={
+          metadata.partial
+            ? "timelines.events.smtp_failed.content_partial"
+            : "timelines.events.smtp_failed.content"
+        }
+        components={[
+          <>
+            {failed.map((email, index) => (
+              <span key={email}>
+                {index > 0 ? ", " : ""}
+                <Link href={"mailto:" + email}>{email}</Link>
+              </span>
+            ))}
+          </>,
+        ]}
+      />
+    );
+  }
+
   if (metadata?.event_type === "quote_signed") {
     message = (
       <Trans

--- a/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
+++ b/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
@@ -375,6 +375,33 @@ export const InvoicesDetailsPage = ({
                     Tacite reconduction
                   </Badge>
                 )}
+              {!!draft.state_details?.email_status && (
+                <Tooltip
+                  content={
+                    draft.state_details.email_status === "partial"
+                      ? "Le document n'a pas pu être envoyé à certains destinataires : " +
+                        (
+                          draft.state_details.email_failed_recipients || []
+                        ).join(", ")
+                      : "Le document n'a pas pu être envoyé : " +
+                        (
+                          draft.state_details.email_failed_recipients || []
+                        ).join(", ")
+                  }
+                >
+                  <Badge
+                    className="ml-2"
+                    variant="soft"
+                    color="red"
+                    size="2"
+                  >
+                    <ExclamationCircleIcon className="h-3 w-3 inline-block mr-1 -mt-0.5" />
+                    {draft.state_details.email_status === "partial"
+                      ? "Envoi partiel"
+                      : "Problème d'envoi"}
+                  </Badge>
+                </Tooltip>
+              )}
               <div className="grow" />
               {draft.type === "invoices" && (
                 <TagPaymentCompletion invoice={draft} />

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -20,6 +20,21 @@ export class InvoicesBase {
   };
 }
 
+export class InvoiceStateDetails {
+  // Extra details attached to the CURRENT state of the document.
+  // Reset automatically whenever the document state changes (see the invoices
+  // upsert-hook). Kept generic on purpose so it can carry other per-state
+  // details in the future.
+
+  // Email delivery status of the last send attempt done in the current state:
+  //   ""        -> nothing to report
+  //   "partial" -> at least one recipient received the email, some were rejected
+  //   "failed"  -> every recipient was rejected
+  email_status: "" | "partial" | "failed" = "";
+  // Recipients rejected by the mail server on the last send attempt.
+  email_failed_recipients = ["string"];
+}
+
 export class FromSubscription {
   // When invoice was generated from a subscription, details goes there
   frequency: "daily" | "weekly" | "monthly" | "yearly" | string = "monthly";


### PR DESCRIPTION
Email send errors were silently swallowed by PushEMail.push, so a rejected
recipient (e.g. "all recipients were rejected: domain not found") left no
trace on the document: no timeline event, no notification, nothing.

- PushEMail.push now returns whether the email was actually delivered
  (backward-compatible: existing callers ignore the result).
- Both send flows (signing-sessions send-invoice and the direct/recurring
  sendPdf) track per-recipient success and record the outcome.
- On failure a "smtp_failed" event is added to the document timeline and a
  notification is fanned out to the subscribed users, differentiating a total
  failure (no recipient received it) from a partial send (some did).
- The document is flagged via a new generic `state_details` column so a
  "Problème d'envoi" / "Envoi partiel" tag shows on the document. The flag is
  reset automatically whenever the state changes (upsert-hook), and cleared
  once a later send goes through.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FwwQQxSRMAf2nmtNLnbiEv