### PR TITLE
fix(timeline): separate recipient emails with commas in sent events

### DIFF
--- a/backend/src/platform/push-email/adapters/file.ts
+++ b/backend/src/platform/push-email/adapters/file.ts
@@ -2,7 +2,10 @@ import config from "config";
 import fs from "fs";
 import Framework from "../..";
 import { Logger } from "../../logger-db";
-import { PushEMailInterfaceAdapterInterface } from "../api";
+import {
+  EmailSendResultCallback,
+  PushEMailInterfaceAdapterInterface,
+} from "../api";
 
 export default class PushEMailFile
   implements PushEMailInterfaceAdapterInterface
@@ -17,18 +20,23 @@ export default class PushEMailFile
     return this;
   }
 
-  async push(email: {
-    to: string[];
-    message: {
-      html: string;
-      text: string;
-      subject: string;
-    };
-    from: string;
-  }) {
+  async push(
+    email: {
+      to: string[];
+      message: {
+        html: string;
+        text: string;
+        subject: string;
+      };
+      from: string;
+    },
+    _smtp?: unknown,
+    onResult?: EmailSendResultCallback
+  ) {
     const path = config.get<string>("email.file.path");
     const filename = `${path}/${Date.now()}.txt`;
     this.logger.info(null, `Writing email to file: ${filename}`);
     fs.writeFileSync(filename, email.message.text);
+    onResult?.({ success: true });
   }
 }

--- a/backend/src/platform/push-email/adapters/ses.ts
+++ b/backend/src/platform/push-email/adapters/ses.ts
@@ -1,6 +1,9 @@
 import config from "config";
 import { SES } from "@aws-sdk/client-ses";
-import { PushEMailInterfaceAdapterInterface } from "../api";
+import {
+  EmailSendResultCallback,
+  PushEMailInterfaceAdapterInterface,
+} from "../api";
 import { EmailAttachment } from "..";
 import Framework from "../..";
 import { Logger } from "../../logger-db";
@@ -52,9 +55,15 @@ export default class PushEMailSES
     };
     from: string;
     attachments?: EmailAttachment[];
-  }) {
+  },
+  _smtp?: unknown,
+  onResult?: EmailSendResultCallback) {
     this.logger.info(null, `Sending email via SES to ${email.to.join(", ")}`);
 
+    // Fire-and-forget: SES answers asynchronously, so we report the real
+    // outcome through `onResult` when the SendRawEmail callback fires rather
+    // than blocking the caller. Uses the same SendRawEmail call as before, so
+    // no additional AWS permission is required.
     this.transporter.sendMail(
       {
         from: email.from,
@@ -67,12 +76,14 @@ export default class PushEMailSES
       (err, info) => {
         if (err) {
           this.logger.error(null, "SES send failed", err);
+          onResult?.({ success: false, error: err?.message || String(err) });
         } else {
           this.logger.info(
             null,
             "SES email sent successfully",
             _.omit(info, "raw")
           );
+          onResult?.({ success: true });
         }
       }
     );

--- a/backend/src/platform/push-email/adapters/smtp.spec.ts
+++ b/backend/src/platform/push-email/adapters/smtp.spec.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const sendMail = jest.fn();
+
+jest.mock("nodemailer", () => ({
+  __esModule: true,
+  default: { createTransport: () => ({ sendMail }) },
+}));
+
+// Framework (../..) is only used for the logger here.
+jest.mock("../..", () => ({
+  __esModule: true,
+  default: { LoggerDb: { get: () => ({ info() {}, error() {} }) } },
+}));
+
+import PushEMailSmtp from "./smtp";
+
+const smtp = {
+  enabled: true,
+  from: "me@example.com",
+  host: "smtp.example.com",
+  port: 587,
+  user: "u",
+  pass: "p",
+  tls: false,
+} as any;
+
+const email = {
+  to: ["a@b.com"],
+  message: { html: "<p>hi</p>", text: "hi", subject: "s" },
+  from: "me@example.com",
+};
+
+const build = async () => {
+  const adapter = new PushEMailSmtp();
+  await adapter.init();
+  return adapter;
+};
+
+describe("PushEMailSmtp.push", () => {
+  beforeEach(() => sendMail.mockReset());
+
+  test("reports success when the recipient is accepted", async () => {
+    sendMail.mockResolvedValue({
+      accepted: ["a@b.com"],
+      rejected: [],
+      response: "250 OK",
+    } as never);
+    const onResult = jest.fn();
+
+    const adapter = await build();
+    await adapter.push(email, smtp, onResult);
+
+    expect(onResult).toHaveBeenCalledWith({ success: true });
+  });
+
+  test("reports failure (without throwing) when sendMail resolves with a rejected recipient", async () => {
+    sendMail.mockResolvedValue({
+      accepted: [],
+      rejected: ["a@b.com"],
+      response: "550 No such user",
+    } as never);
+    const onResult = jest.fn();
+
+    const adapter = await build();
+    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
+
+    expect(onResult).toHaveBeenCalledTimes(1);
+    const result = onResult.mock.calls[0][0] as any;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("a@b.com");
+  });
+
+  test("reports failure (without rethrowing) when the send throws an envelope rejection", async () => {
+    sendMail.mockRejectedValue({
+      code: "EENVELOPE",
+      responseCode: 550,
+      rejected: ["a@b.com"],
+      message: "Mailbox unavailable",
+    } as never);
+    const onResult = jest.fn();
+
+    const adapter = await build();
+    // Must NOT rethrow: a bad mailbox won't be fixed by the fallback provider.
+    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
+
+    const result = onResult.mock.calls[0][0] as any;
+    expect(result.success).toBe(false);
+  });
+
+  test("rethrows a connection/transport error so the caller can fall back", async () => {
+    sendMail.mockRejectedValue({
+      code: "ECONNECTION",
+      message: "connect ECONNREFUSED",
+    } as never);
+    const onResult = jest.fn();
+
+    const adapter = await build();
+    await expect(adapter.push(email, smtp, onResult)).rejects.toMatchObject({
+      code: "ECONNECTION",
+    });
+
+    // No definitive failure reported: the fallback adapter will report instead.
+    expect(onResult).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/platform/push-email/adapters/smtp.spec.ts
+++ b/backend/src/platform/push-email/adapters/smtp.spec.ts
@@ -10,7 +10,7 @@ jest.mock("nodemailer", () => ({
 // Framework (../..) is only used for the logger here.
 jest.mock("../..", () => ({
   __esModule: true,
-  default: { LoggerDb: { get: () => ({ info() {}, error() {} }) } },
+  default: { LoggerDb: { get: () => ({ info: jest.fn(), error: jest.fn() }) } },
 }));
 
 import PushEMailSmtp from "./smtp";

--- a/backend/src/platform/push-email/adapters/smtp.spec.ts
+++ b/backend/src/platform/push-email/adapters/smtp.spec.ts
@@ -59,7 +59,7 @@ describe("PushEMailSmtp.push", () => {
     expect(onResult).toHaveBeenCalledWith({ success: true });
   });
 
-  test("reports a partial failure (no fallback) when some recipients are accepted and some rejected", async () => {
+  test("reports a definitive (non-retryable) failure when some recipients are accepted and some rejected", async () => {
     sendMail.mockResolvedValue({
       accepted: ["a@b.com"],
       rejected: ["bad@nope.com"],
@@ -68,7 +68,6 @@ describe("PushEMailSmtp.push", () => {
     const onResult = jest.fn();
 
     const adapter = await build();
-    // Resolves (no rethrow): the transport works, only one mailbox is bad.
     await expect(
       adapter.push(emailMulti, smtp, onResult)
     ).resolves.toBeUndefined();
@@ -76,10 +75,12 @@ describe("PushEMailSmtp.push", () => {
     expect(onResult).toHaveBeenCalledTimes(1);
     const result = onResult.mock.calls[0][0] as any;
     expect(result.success).toBe(false);
+    // Transport works, so no fallback: the failure is not retryable.
+    expect(result.retryable).toBeFalsy();
     expect(result.error).toContain("bad@nope.com");
   });
 
-  test("throws (so the caller falls back) when no recipient is accepted", async () => {
+  test("reports a retryable failure (→ fallback) when no recipient is accepted", async () => {
     sendMail.mockResolvedValue({
       accepted: [],
       rejected: ["a@b.com"],
@@ -88,12 +89,14 @@ describe("PushEMailSmtp.push", () => {
     const onResult = jest.fn();
 
     const adapter = await build();
-    // Can't tell a bad mailbox from a misconfigured SMTP → fall back.
-    await expect(adapter.push(email, smtp, onResult)).rejects.toBeTruthy();
-    expect(onResult).not.toHaveBeenCalled();
+    // Can't tell a bad mailbox from a misconfigured SMTP → retryable.
+    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
+    const result = onResult.mock.calls[0][0] as any;
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(true);
   });
 
-  test("rethrows an envelope/recipient error so the caller can fall back", async () => {
+  test("reports a retryable failure on an envelope/recipient error", async () => {
     sendMail.mockRejectedValue({
       code: "EENVELOPE",
       responseCode: 550,
@@ -103,13 +106,13 @@ describe("PushEMailSmtp.push", () => {
     const onResult = jest.fn();
 
     const adapter = await build();
-    await expect(adapter.push(email, smtp, onResult)).rejects.toMatchObject({
-      code: "EENVELOPE",
-    });
-    expect(onResult).not.toHaveBeenCalled();
+    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
+    const result = onResult.mock.calls[0][0] as any;
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(true);
   });
 
-  test("rethrows a connection/transport error so the caller can fall back", async () => {
+  test("reports a retryable failure on a connection/transport error", async () => {
     sendMail.mockRejectedValue({
       code: "ECONNECTION",
       message: "connect ECONNREFUSED",
@@ -117,11 +120,9 @@ describe("PushEMailSmtp.push", () => {
     const onResult = jest.fn();
 
     const adapter = await build();
-    await expect(adapter.push(email, smtp, onResult)).rejects.toMatchObject({
-      code: "ECONNECTION",
-    });
-
-    // No definitive failure reported: the fallback adapter will report instead.
-    expect(onResult).not.toHaveBeenCalled();
+    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
+    const result = onResult.mock.calls[0][0] as any;
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(true);
   });
 });

--- a/backend/src/platform/push-email/adapters/smtp.spec.ts
+++ b/backend/src/platform/push-email/adapters/smtp.spec.ts
@@ -31,6 +31,11 @@ const email = {
   from: "me@example.com",
 };
 
+const emailMulti = {
+  ...email,
+  to: ["a@b.com", "bad@nope.com"],
+};
+
 const build = async () => {
   const adapter = new PushEMailSmtp();
   await adapter.init();
@@ -54,7 +59,27 @@ describe("PushEMailSmtp.push", () => {
     expect(onResult).toHaveBeenCalledWith({ success: true });
   });
 
-  test("reports failure (without throwing) when sendMail resolves with a rejected recipient", async () => {
+  test("reports a partial failure (no fallback) when some recipients are accepted and some rejected", async () => {
+    sendMail.mockResolvedValue({
+      accepted: ["a@b.com"],
+      rejected: ["bad@nope.com"],
+      response: "250 OK",
+    } as never);
+    const onResult = jest.fn();
+
+    const adapter = await build();
+    // Resolves (no rethrow): the transport works, only one mailbox is bad.
+    await expect(
+      adapter.push(emailMulti, smtp, onResult)
+    ).resolves.toBeUndefined();
+
+    expect(onResult).toHaveBeenCalledTimes(1);
+    const result = onResult.mock.calls[0][0] as any;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("bad@nope.com");
+  });
+
+  test("throws (so the caller falls back) when no recipient is accepted", async () => {
     sendMail.mockResolvedValue({
       accepted: [],
       rejected: ["a@b.com"],
@@ -63,15 +88,12 @@ describe("PushEMailSmtp.push", () => {
     const onResult = jest.fn();
 
     const adapter = await build();
-    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
-
-    expect(onResult).toHaveBeenCalledTimes(1);
-    const result = onResult.mock.calls[0][0] as any;
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("a@b.com");
+    // Can't tell a bad mailbox from a misconfigured SMTP → fall back.
+    await expect(adapter.push(email, smtp, onResult)).rejects.toBeTruthy();
+    expect(onResult).not.toHaveBeenCalled();
   });
 
-  test("reports failure (without rethrowing) when the send throws an envelope rejection", async () => {
+  test("rethrows an envelope/recipient error so the caller can fall back", async () => {
     sendMail.mockRejectedValue({
       code: "EENVELOPE",
       responseCode: 550,
@@ -81,11 +103,10 @@ describe("PushEMailSmtp.push", () => {
     const onResult = jest.fn();
 
     const adapter = await build();
-    // Must NOT rethrow: a bad mailbox won't be fixed by the fallback provider.
-    await expect(adapter.push(email, smtp, onResult)).resolves.toBeUndefined();
-
-    const result = onResult.mock.calls[0][0] as any;
-    expect(result.success).toBe(false);
+    await expect(adapter.push(email, smtp, onResult)).rejects.toMatchObject({
+      code: "EENVELOPE",
+    });
+    expect(onResult).not.toHaveBeenCalled();
   });
 
   test("rethrows a connection/transport error so the caller can fall back", async () => {

--- a/backend/src/platform/push-email/adapters/smtp.ts
+++ b/backend/src/platform/push-email/adapters/smtp.ts
@@ -80,10 +80,10 @@ export default class PushEMailSmtp
         },
       };
 
-      // nodemailer returns per-recipient outcome: `accepted`/`rejected` list
-      // the recipients the destination server acknowledged or refused during
-      // the SMTP dialogue (RCPT TO), plus its final `response` line. It only
-      // throws when the message couldn't be delivered to ANY recipient.
+      // nodemailer returns per-recipient outcome: `accepted`/`rejected` are the
+      // recipients the destination server acknowledged or refused during the
+      // SMTP dialogue (RCPT TO), plus its final `response` line. It only throws
+      // when the message couldn't be delivered to ANY recipient.
       const info = (await transporter.sendMail(mailOptions)) as {
         accepted?: unknown[];
         rejected?: unknown[];
@@ -93,8 +93,24 @@ export default class PushEMailSmtp
       const rejected = info?.rejected ?? [];
       const accepted = info?.accepted ?? [];
 
-      if (rejected.length > 0 || accepted.length === 0) {
-        // The server accepted the connection but refused the recipient(s).
+      if (accepted.length === 0) {
+        // Nobody accepted the message. We can't tell a genuinely bad mailbox
+        // apart from a misconfigured custom SMTP (relay/sender denied, auth),
+        // so treat it as a transport failure and let the caller fall back to
+        // the default adapter — a misconfigured SMTP must not block delivery.
+        throw new Error(
+          `SMTP delivery failed via ${smtp.host}: ${rejectedDetail(
+            rejected,
+            info?.response
+          )}`
+        );
+      }
+
+      if (rejected.length > 0) {
+        // Partial: the transport clearly works (some recipients were
+        // accepted), so the rejected ones are genuinely bad recipients. Report
+        // them without falling back — a different provider won't fix a bad
+        // mailbox, and the good recipients already received the document.
         const detail = rejectedDetail(rejected, info?.response);
         this.logger.error(
           null,
@@ -112,49 +128,14 @@ export default class PushEMailSmtp
       );
       onResult?.({ success: true });
     } catch (error: any) {
-      // Distinguish a per-recipient rejection (permanent: bad mailbox / policy
-      // — a different provider wouldn't help) from a transport/connection error
-      // (the custom SMTP is unreachable → let the caller fall back).
-      if (isRecipientRejection(error)) {
-        const detail = rejectedDetail(
-          error?.rejected,
-          error?.response || error?.message
-        );
-        this.logger.error(
-          null,
-          `SMTP recipient(s) rejected via ${smtp.host}: ${detail}`
-        );
-        onResult?.({ success: false, error: detail });
-        return; // do NOT rethrow: no fallback for a bad recipient
-      }
-
       this.logger.error(null, `SMTP send failed via ${smtp.host}`, error);
-      // Transport/connection failure: rethrow so the caller can fall back to
-      // the default adapter (which then reports the real outcome).
+      // Any total failure (connection, auth, relay denied, or all recipients
+      // rejected) is rethrown so the caller can fall back to the default
+      // adapter, which then reports the real outcome.
       throw error;
     }
   }
 }
-
-/**
- * Whether a nodemailer error represents recipients being rejected by the
- * server (as opposed to a connection/auth/transport failure). nodemailer flags
- * envelope errors with `code: "EENVELOPE"` and/or a `rejected` list, and a 5xx
- * `responseCode` means a permanent SMTP-level refusal.
- */
-const isRecipientRejection = (error: any): boolean => {
-  if (!error) return false;
-  if (Array.isArray(error.rejected) && error.rejected.length > 0) return true;
-  if (error.code === "EENVELOPE") return true;
-  if (
-    typeof error.responseCode === "number" &&
-    error.responseCode >= 500 &&
-    error.responseCode < 600
-  ) {
-    return true;
-  }
-  return false;
-};
 
 /** Human-readable reason for a recipient rejection, for logs and the timeline. */
 const rejectedDetail = (rejected: unknown, response?: string): string => {

--- a/backend/src/platform/push-email/adapters/smtp.ts
+++ b/backend/src/platform/push-email/adapters/smtp.ts
@@ -93,25 +93,24 @@ export default class PushEMailSmtp
       const rejected = info?.rejected ?? [];
       const accepted = info?.accepted ?? [];
 
-      if (accepted.length === 0) {
-        // Nobody accepted the message. We can't tell a genuinely bad mailbox
-        // apart from a misconfigured custom SMTP (relay/sender denied, auth),
-        // so treat it as a transport failure and let the caller fall back to
-        // the default adapter — a misconfigured SMTP must not block delivery.
-        throw new Error(
-          `SMTP delivery failed via ${smtp.host}: ${rejectedDetail(
-            rejected,
-            info?.response
-          )}`
+      if (rejected.length === 0) {
+        this.logger.info(
+          null,
+          `SMTP email sent successfully via ${smtp.host}${
+            info?.response ? ` (${info.response})` : ""
+          }`
         );
+        onResult?.({ success: true });
+        return;
       }
 
-      if (rejected.length > 0) {
+      const detail = rejectedDetail(rejected, info?.response);
+
+      if (accepted.length > 0) {
         // Partial: the transport clearly works (some recipients were
         // accepted), so the rejected ones are genuinely bad recipients. Report
-        // them without falling back — a different provider won't fix a bad
-        // mailbox, and the good recipients already received the document.
-        const detail = rejectedDetail(rejected, info?.response);
+        // a definitive (non-retryable) failure — a different provider won't fix
+        // a bad mailbox, and the good recipients already received the document.
         this.logger.error(
           null,
           `SMTP recipient(s) rejected via ${smtp.host}: ${detail}`
@@ -120,19 +119,20 @@ export default class PushEMailSmtp
         return;
       }
 
-      this.logger.info(
-        null,
-        `SMTP email sent successfully via ${smtp.host}${
-          info?.response ? ` (${info.response})` : ""
-        }`
-      );
-      onResult?.({ success: true });
+      // Nobody accepted: could be bad mailboxes OR a misconfigured custom SMTP
+      // (relay/sender denied). Ambiguous → retryable, so PushEMail falls back
+      // to the default adapter (a misconfigured SMTP must not block delivery).
+      this.logger.error(null, `SMTP delivery failed via ${smtp.host}: ${detail}`);
+      onResult?.({ success: false, retryable: true, error: detail });
     } catch (error: any) {
+      // Connection / auth / relay failure: the SMTP itself is unusable, so this
+      // is retryable — PushEMail falls back to the default adapter.
       this.logger.error(null, `SMTP send failed via ${smtp.host}`, error);
-      // Any total failure (connection, auth, relay denied, or all recipients
-      // rejected) is rethrown so the caller can fall back to the default
-      // adapter, which then reports the real outcome.
-      throw error;
+      onResult?.({
+        success: false,
+        retryable: true,
+        error: error?.message || String(error),
+      });
     }
   }
 }

--- a/backend/src/platform/push-email/adapters/smtp.ts
+++ b/backend/src/platform/push-email/adapters/smtp.ts
@@ -80,14 +80,87 @@ export default class PushEMailSmtp
         },
       };
 
-      await transporter.sendMail(mailOptions);
-      this.logger.info(null, `SMTP email sent successfully via ${smtp.host}`);
+      // nodemailer returns per-recipient outcome: `accepted`/`rejected` list
+      // the recipients the destination server acknowledged or refused during
+      // the SMTP dialogue (RCPT TO), plus its final `response` line. It only
+      // throws when the message couldn't be delivered to ANY recipient.
+      const info = (await transporter.sendMail(mailOptions)) as {
+        accepted?: unknown[];
+        rejected?: unknown[];
+        response?: string;
+      };
+
+      const rejected = info?.rejected ?? [];
+      const accepted = info?.accepted ?? [];
+
+      if (rejected.length > 0 || accepted.length === 0) {
+        // The server accepted the connection but refused the recipient(s).
+        const detail = rejectedDetail(rejected, info?.response);
+        this.logger.error(
+          null,
+          `SMTP recipient(s) rejected via ${smtp.host}: ${detail}`
+        );
+        onResult?.({ success: false, error: detail });
+        return;
+      }
+
+      this.logger.info(
+        null,
+        `SMTP email sent successfully via ${smtp.host}${
+          info?.response ? ` (${info.response})` : ""
+        }`
+      );
       onResult?.({ success: true });
     } catch (error: any) {
+      // Distinguish a per-recipient rejection (permanent: bad mailbox / policy
+      // — a different provider wouldn't help) from a transport/connection error
+      // (the custom SMTP is unreachable → let the caller fall back).
+      if (isRecipientRejection(error)) {
+        const detail = rejectedDetail(
+          error?.rejected,
+          error?.response || error?.message
+        );
+        this.logger.error(
+          null,
+          `SMTP recipient(s) rejected via ${smtp.host}: ${detail}`
+        );
+        onResult?.({ success: false, error: detail });
+        return; // do NOT rethrow: no fallback for a bad recipient
+      }
+
       this.logger.error(null, `SMTP send failed via ${smtp.host}`, error);
-      // Rethrow (without reporting a definitive failure): the caller may still
-      // fall back to the default adapter, which reports the real outcome.
+      // Transport/connection failure: rethrow so the caller can fall back to
+      // the default adapter (which then reports the real outcome).
       throw error;
     }
   }
 }
+
+/**
+ * Whether a nodemailer error represents recipients being rejected by the
+ * server (as opposed to a connection/auth/transport failure). nodemailer flags
+ * envelope errors with `code: "EENVELOPE"` and/or a `rejected` list, and a 5xx
+ * `responseCode` means a permanent SMTP-level refusal.
+ */
+const isRecipientRejection = (error: any): boolean => {
+  if (!error) return false;
+  if (Array.isArray(error.rejected) && error.rejected.length > 0) return true;
+  if (error.code === "EENVELOPE") return true;
+  if (
+    typeof error.responseCode === "number" &&
+    error.responseCode >= 500 &&
+    error.responseCode < 600
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/** Human-readable reason for a recipient rejection, for logs and the timeline. */
+const rejectedDetail = (rejected: unknown, response?: string): string => {
+  const list = Array.isArray(rejected)
+    ? rejected.map((r) => (typeof r === "string" ? r : JSON.stringify(r)))
+    : [];
+  const who = list.length ? `rejected: ${list.join(", ")}` : "no recipient accepted";
+  return response ? `${who} (${response})` : who;
+};

--- a/backend/src/platform/push-email/adapters/smtp.ts
+++ b/backend/src/platform/push-email/adapters/smtp.ts
@@ -1,6 +1,10 @@
 import nodemailer from "nodemailer";
 import { EmailAttachment } from "..";
-import { PushEMailInterfaceAdapterInterface, SmtpOptions } from "../api";
+import {
+  EmailSendResultCallback,
+  PushEMailInterfaceAdapterInterface,
+  SmtpOptions,
+} from "../api";
 import Framework from "../..";
 import { Logger } from "../../logger-db";
 
@@ -26,7 +30,8 @@ export default class PushEMailSmtp
       from: string;
       attachments?: EmailAttachment[];
     },
-    smtp: SmtpOptions
+    smtp: SmtpOptions,
+    onResult?: EmailSendResultCallback
   ) {
     this.logger.info(
       null,
@@ -77,8 +82,11 @@ export default class PushEMailSmtp
 
       await transporter.sendMail(mailOptions);
       this.logger.info(null, `SMTP email sent successfully via ${smtp.host}`);
+      onResult?.({ success: true });
     } catch (error: any) {
       this.logger.error(null, `SMTP send failed via ${smtp.host}`, error);
+      // Rethrow (without reporting a definitive failure): the caller may still
+      // fall back to the default adapter, which reports the real outcome.
       throw error;
     }
   }

--- a/backend/src/platform/push-email/api.ts
+++ b/backend/src/platform/push-email/api.ts
@@ -16,6 +16,17 @@ export type SmtpOptions = {
   };
 };
 
+/**
+ * Outcome of an email send attempt as reported by the underlying transport.
+ * `success` reflects whether the transport *accepted* the message for delivery
+ * (SMTP: the server accepted it; SES: SendRawEmail returned without error). It
+ * does NOT reflect an asynchronous bounce that may happen later — detecting
+ * those would require SNS/DSN feedback, which we deliberately don't wire here.
+ */
+export type EmailSendResult = { success: boolean; error?: string };
+
+export type EmailSendResultCallback = (result: EmailSendResult) => void;
+
 export interface PushEMailInterfaceAdapterInterface extends PlatformService {
   push(
     email: {
@@ -28,6 +39,9 @@ export interface PushEMailInterfaceAdapterInterface extends PlatformService {
       attachments?: EmailAttachment[];
       from: string;
     },
-    smtp?: SmtpOptions
+    smtp?: SmtpOptions,
+    // Invoked once the transport knows the real outcome. For SES this happens
+    // asynchronously, after `push` has already resolved, hence the callback.
+    onResult?: EmailSendResultCallback
   ): Promise<void>;
 }

--- a/backend/src/platform/push-email/api.ts
+++ b/backend/src/platform/push-email/api.ts
@@ -23,7 +23,17 @@ export type SmtpOptions = {
  * does NOT reflect an asynchronous bounce that may happen later — detecting
  * those would require SNS/DSN feedback, which we deliberately don't wire here.
  */
-export type EmailSendResult = { success: boolean; error?: string };
+export type EmailSendResult = {
+  success: boolean;
+  error?: string;
+  // Only meaningful for the primary (custom SMTP) attempt. `true` means the
+  // failure is a transport/configuration problem — nobody could be reached, so
+  // it's ambiguous whether the recipients or the SMTP setup are at fault — and
+  // PushEMail should fall back to the default adapter. A definitive result
+  // (delivered, or specific recipients rejected while others succeeded) is not
+  // retryable and must not trigger a fallback.
+  retryable?: boolean;
+};
 
 export type EmailSendResultCallback = (result: EmailSendResult) => void;
 

--- a/backend/src/platform/push-email/index.spec.ts
+++ b/backend/src/platform/push-email/index.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import type { EmailSendResult } from "./api";
+
+jest.mock("./build-email", () => ({
+  __esModule: true,
+  buildHTML: async () => ({ html: "<b>x</b>", text: "x" }),
+}));
+
+jest.mock("@sentry/node", () => ({
+  __esModule: true,
+  captureException: () => {},
+}));
+
+const cfg: Record<string, string> = {
+  "server.domain": "app.example.com", // no "demo" → no whitelisting
+  "email.from_name": "L'inventaire",
+  "email.from": "no-reply@example.com",
+};
+jest.mock("config", () => ({
+  __esModule: true,
+  default: { get: (k: string) => cfg[k], has: () => false },
+}));
+
+// Framework/platform (both are the default export of "..") — only I18n + logger.
+jest.mock("..", () => ({
+  __esModule: true,
+  default: {
+    I18n: { getLanguage: () => "fr", t: () => "" },
+    LoggerDb: { get: () => ({ info() {}, error() {} }) },
+  },
+}));
+
+import PushEMail from "./index";
+
+const ctx = {} as any;
+const smtpOpts = { enabled: true } as any;
+
+// Build a PushEMail with injected fake adapters (skip init()).
+const buildWith = (
+  smtpBehaviour: EmailSendResult | undefined,
+  defaultBehaviour: EmailSendResult = { success: true }
+) => {
+  const smtpPush = jest.fn(
+    async (_body: any, _smtp: any, onResult?: (r: EmailSendResult) => void) => {
+      if (smtpBehaviour) onResult?.(smtpBehaviour);
+    }
+  );
+  const defaultPush = jest.fn(
+    async (_body: any, _smtp: any, onResult?: (r: EmailSendResult) => void) => {
+      onResult?.(defaultBehaviour);
+    }
+  );
+
+  const pe = new PushEMail();
+  (pe as any).logger = { info() {}, error() {} };
+  (pe as any).smtpService = { push: smtpPush };
+  (pe as any).service = { push: defaultPush };
+
+  return { pe, smtpPush, defaultPush };
+};
+
+describe("PushEMail.push fallback policy", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("custom SMTP succeeds → no fallback, success forwarded", async () => {
+    const { pe, defaultPush } = buildWith({ success: true });
+    const onResult = jest.fn();
+
+    const ret = await pe.push(ctx, "a@b.com", "m", {}, smtpOpts, onResult);
+
+    expect(ret).toBe(true);
+    expect(defaultPush).not.toHaveBeenCalled();
+    expect(onResult).toHaveBeenCalledWith({ success: true });
+  });
+
+  test("SMTP rejects a recipient (not retryable) → no fallback, failure forwarded", async () => {
+    const { pe, defaultPush } = buildWith({
+      success: false,
+      error: "rejected: bad@x.com",
+    });
+    const onResult = jest.fn();
+
+    const ret = await pe.push(ctx, "a@b.com", "m", {}, smtpOpts, onResult);
+
+    expect(ret).toBe(false);
+    expect(defaultPush).not.toHaveBeenCalled();
+    expect(onResult).toHaveBeenCalledWith({
+      success: false,
+      error: "rejected: bad@x.com",
+    });
+  });
+
+  test("SMTP unusable (retryable) → falls back to default adapter", async () => {
+    const { pe, smtpPush, defaultPush } = buildWith(
+      { success: false, retryable: true, error: "ECONNECTION" },
+      { success: true }
+    );
+    const onResult = jest.fn();
+
+    const ret = await pe.push(ctx, "a@b.com", "m", {}, smtpOpts, onResult);
+
+    expect(smtpPush).toHaveBeenCalledTimes(1);
+    expect(defaultPush).toHaveBeenCalledTimes(1);
+    expect(ret).toBe(true);
+    // The forwarded result comes from the fallback adapter, not the SMTP one.
+    expect(onResult).toHaveBeenLastCalledWith({ success: true });
+  });
+
+  test("no custom SMTP → default adapter is used directly", async () => {
+    const { pe, smtpPush, defaultPush } = buildWith(undefined, {
+      success: true,
+    });
+    const onResult = jest.fn();
+
+    const ret = await pe.push(ctx, "a@b.com", "m", {}, undefined, onResult);
+
+    expect(smtpPush).not.toHaveBeenCalled();
+    expect(defaultPush).toHaveBeenCalledTimes(1);
+    expect(ret).toBe(true);
+    expect(onResult).toHaveBeenCalledWith({ success: true });
+  });
+});

--- a/backend/src/platform/push-email/index.spec.ts
+++ b/backend/src/platform/push-email/index.spec.ts
@@ -8,7 +8,7 @@ jest.mock("./build-email", () => ({
 
 jest.mock("@sentry/node", () => ({
   __esModule: true,
-  captureException: () => {},
+  captureException: jest.fn(),
 }));
 
 const cfg: Record<string, string> = {
@@ -26,7 +26,7 @@ jest.mock("..", () => ({
   __esModule: true,
   default: {
     I18n: { getLanguage: () => "fr", t: () => "" },
-    LoggerDb: { get: () => ({ info() {}, error() {} }) },
+    LoggerDb: { get: () => ({ info: jest.fn(), error: jest.fn() }) },
   },
 }));
 
@@ -52,7 +52,7 @@ const buildWith = (
   );
 
   const pe = new PushEMail();
-  (pe as any).logger = { info() {}, error() {} };
+  (pe as any).logger = { info: jest.fn(), error: jest.fn() };
   (pe as any).smtpService = { push: smtpPush };
   (pe as any).service = { push: defaultPush };
 

--- a/backend/src/platform/push-email/index.ts
+++ b/backend/src/platform/push-email/index.ts
@@ -4,7 +4,11 @@ import { Context as Context } from "../../types";
 import { PlatformService } from "../types";
 import PushEMailFile from "./adapters/file";
 import PushEMailSES from "./adapters/ses";
-import { PushEMailInterfaceAdapterInterface, SmtpOptions } from "./api";
+import {
+  EmailSendResultCallback,
+  PushEMailInterfaceAdapterInterface,
+  SmtpOptions,
+} from "./api";
 import { buildHTML } from "./build-email";
 import Framework from "..";
 import PushEMailSmtp from "./adapters/smtp";
@@ -55,7 +59,12 @@ export default class PushEMail implements PlatformService {
       post_receipt?: string;
       attachments?: EmailAttachment[];
     } = {},
-    smtp?: SmtpOptions
+    smtp?: SmtpOptions,
+    // Optional: reports the transport's real send outcome. For SES this fires
+    // asynchronously, after this method has already returned its optimistic
+    // boolean, which is why callers that care about failures must rely on this
+    // callback (e.g. through a deferred check) rather than the return value.
+    onResult?: EmailSendResultCallback
   ): Promise<boolean> {
     const language = platform.I18n.getLanguage(context);
     options.subject = options.subject || "New notification from L'Inventaire";
@@ -73,6 +82,7 @@ export default class PushEMail implements PlatformService {
     } catch (e: any) {
       platform.LoggerDb.get("push-email").error(context, e);
       captureException(e);
+      onResult?.({ success: false, error: "Failed to render email" });
       return false;
     }
 
@@ -122,20 +132,21 @@ export default class PushEMail implements PlatformService {
       if (smtp?.enabled) {
         try {
           this.logger.info(context, "Using custom SMTP configuration");
-          await this.smtpService.push(body, smtp);
+          await this.smtpService.push(body, smtp, onResult);
           this.logger.info(context, "Email sent successfully via SMTP");
         } catch (e: any) {
           captureException(e);
           this.logger.error(context, "SMTP send failed", e);
           this.logger.info(context, "Falling back to default adapter");
-          await this.service.push(body);
+          // The fallback adapter reports the real outcome via onResult.
+          await this.service.push(body, undefined, onResult);
           this.logger.info(
             context,
             "Email sent successfully via fallback adapter"
           );
         }
       } else {
-        await this.service.push(body);
+        await this.service.push(body, undefined, onResult);
         this.logger.info(
           context,
           "Email sent successfully via default adapter"
@@ -144,6 +155,7 @@ export default class PushEMail implements PlatformService {
       return true;
     } catch (err) {
       this.logger.error(context, "Failed to send email", err);
+      onResult?.({ success: false, error: (err as any)?.message || String(err) });
       return false;
     }
   }

--- a/backend/src/platform/push-email/index.ts
+++ b/backend/src/platform/push-email/index.ts
@@ -5,6 +5,7 @@ import { PlatformService } from "../types";
 import PushEMailFile from "./adapters/file";
 import PushEMailSES from "./adapters/ses";
 import {
+  EmailSendResult,
   EmailSendResultCallback,
   PushEMailInterfaceAdapterInterface,
   SmtpOptions,
@@ -130,28 +131,31 @@ export default class PushEMail implements PlatformService {
         attachments: options.attachments,
       };
       if (smtp?.enabled) {
-        try {
-          this.logger.info(context, "Using custom SMTP configuration");
-          await this.smtpService.push(body, smtp, onResult);
-          this.logger.info(context, "Email sent successfully via SMTP");
-        } catch (e: any) {
-          captureException(e);
-          this.logger.error(context, "SMTP send failed", e);
-          this.logger.info(context, "Falling back to default adapter");
-          // The fallback adapter reports the real outcome via onResult.
-          await this.service.push(body, undefined, onResult);
-          this.logger.info(
-            context,
-            "Email sent successfully via fallback adapter"
-          );
+        this.logger.info(context, "Using custom SMTP configuration");
+
+        // Try the custom SMTP first. It reports its outcome synchronously
+        // through the callback, flagging `retryable` when the SMTP itself is
+        // unusable (transport/config problem) rather than a specific recipient
+        // being rejected.
+        let smtpResult: EmailSendResult | undefined;
+        await this.smtpService.push(body, smtp, (r) => (smtpResult = r));
+
+        if (smtpResult && !smtpResult.retryable) {
+          // Definitive outcome: delivered, or specific recipients rejected
+          // while the transport worked. Don't fall back — forward it as-is.
+          onResult?.(smtpResult);
+          return smtpResult.success;
         }
-      } else {
+
+        // The custom SMTP is unusable: fall back to the default adapter, which
+        // reports the real outcome via onResult.
+        this.logger.info(context, "Falling back to default adapter");
         await this.service.push(body, undefined, onResult);
-        this.logger.info(
-          context,
-          "Email sent successfully via default adapter"
-        );
+        return true;
       }
+
+      await this.service.push(body, undefined, onResult);
+      this.logger.info(context, "Email sent successfully via default adapter");
       return true;
     } catch (err) {
       this.logger.error(context, "Failed to send email", err);

--- a/backend/src/services/modules/invoices/services/email-send-result.spec.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.spec.ts
@@ -14,7 +14,10 @@ jest.mock("#src/services/index", () => ({
   default: { Comments: { createEvent } },
 }));
 
-import { recordEmailSendResult } from "./email-send-result";
+import {
+  recordEmailSendResult,
+  scheduleEmailSendResultCheck,
+} from "./email-send-result";
 
 const ctx = { client_id: "cl-1", id: "us-1", role: "USER" } as any;
 const invoice = (extra: any = {}) =>
@@ -81,5 +84,52 @@ describe("recordEmailSendResult", () => {
 
     const payload = update.mock.calls[0][3] as any;
     expect(payload.state_details.email_status).toBe("partial");
+  });
+});
+
+describe("scheduleEmailSendResultCheck", () => {
+  beforeEach(() => {
+    update.mockReset();
+    createEvent.mockReset();
+    getService.mockClear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("after the delay, flags the recipients the transport rejected", async () => {
+    const recipients = [{ email: "a@b.com" }, { email: "c@d.com" }];
+    const deliveries = {
+      "a@b.com": { success: true },
+      "c@d.com": { success: false, error: "nope" },
+    };
+
+    scheduleEmailSendResultCheck(ctx, invoice(), recipients, deliveries, 1000);
+
+    // Nothing happens before the delay elapses.
+    expect(createEvent).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(createEvent).toHaveBeenCalledTimes(1);
+    const event = createEvent.mock.calls[0][1] as any;
+    expect(event.metadata.event_type).toBe("smtp_failed");
+    expect(event.metadata.partial).toBe(true);
+    expect(event.metadata.emails).toEqual(["c@d.com"]);
+    expect(event.metadata.sent_emails).toEqual(["a@b.com"]);
+  });
+
+  test("treats recipients with no reported result as sent", async () => {
+    const recipients = [{ email: "a@b.com" }];
+    // The transport never reported back by the deadline.
+    const deliveries = {};
+
+    scheduleEmailSendResultCheck(ctx, invoice(), recipients, deliveries, 1000);
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(createEvent).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/modules/invoices/services/email-send-result.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.ts
@@ -1,7 +1,16 @@
 import Framework from "#src/platform/index";
+import type { EmailSendResult } from "#src/platform/push-email/api";
 import Services from "#src/services/index";
 import { Context } from "#src/types";
 import Invoices, { InvoicesDefinition } from "../entities/invoices";
+
+/**
+ * How long we wait, after firing the emails, before checking their send state.
+ * The delay lets the transport report back (SES answers asynchronously). This
+ * is a best-effort, in-memory timer: if the server restarts before it fires,
+ * the check is simply lost — which we accept for simplicity.
+ */
+export const EMAIL_SEND_RESULT_CHECK_DELAY_MS = 30_000;
 
 /**
  * Records the outcome of an email send attempt for a document.
@@ -72,4 +81,45 @@ export const recordEmailSendResult = async (
       },
     }
   );
+};
+
+/**
+ * Schedules a deferred check of the email send outcome.
+ *
+ * The emails are fired without blocking the request; `deliveries` is a shared
+ * map that the transport fills in asynchronously (keyed by recipient email).
+ * After `delayMs` we look at what came back and record the outcome through
+ * `recordEmailSendResult` (timeline event + notification + document flag for
+ * the recipients that were rejected).
+ *
+ * Recipients with no reported result by the deadline are treated as sent — we
+ * only ever flag a *confirmed* rejection. The timer is unref'd so it never
+ * keeps the process alive on its own; if the server restarts first, the check
+ * is lost (accepted trade-off for keeping this simple).
+ */
+export const scheduleEmailSendResultCheck = (
+  ctx: Context,
+  invoice: Invoices,
+  recipients: { email: string }[],
+  deliveries: Record<string, EmailSendResult>,
+  delayMs: number = EMAIL_SEND_RESULT_CHECK_DELAY_MS
+) => {
+  const timer = setTimeout(async () => {
+    try {
+      const failedEmails = recipients
+        .map((r) => r.email)
+        .filter((email) => deliveries[email]?.success === false);
+      const sentEmails = recipients
+        .map((r) => r.email)
+        .filter((email) => !failedEmails.includes(email));
+
+      await recordEmailSendResult(ctx, invoice, sentEmails, failedEmails);
+    } catch (e) {
+      Framework.LoggerDb.get("email-send-result").error(ctx, e as any);
+    }
+  }, delayMs);
+
+  timer.unref?.();
+
+  return timer;
 };

--- a/backend/src/services/modules/signing-sessions/index.ts
+++ b/backend/src/services/modules/signing-sessions/index.ts
@@ -2,6 +2,7 @@ import config from "config";
 import { Express, Router } from "express";
 import { default as Framework, default as platform } from "../../../platform";
 import { Logger } from "../../../platform/logger-db";
+import type { EmailSendResult } from "../../../platform/push-email/api";
 import { InternalApplicationService } from "../../types";
 import DocumensoAdapter from "./adapters/documenso/documenso";
 import InternalAdapter from "./adapters/internal/internal";
@@ -140,6 +141,9 @@ export default class SigningSessionService
     const resultingSigningSessions: SigningSessions[] = [];
     const sentEmails: string[] = [];
     const failedEmails: string[] = [];
+    // Filled in asynchronously by the mail transport (SES reports back after
+    // `push` has returned). A deferred check reads this to detect failures.
+    const deliveries: Record<string, EmailSendResult> = {};
 
     for (const recipient of recipients) {
       if (!recipient) throw new Error("Recipient is wrong");
@@ -189,7 +193,10 @@ export default class SigningSessionService
           attachments: [{ filename: name, content: pdf }],
           logo: htmlLogo,
         },
-        client.smtp
+        client.smtp,
+        (result) => {
+          deliveries[recipient.email] = result;
+        }
       );
 
       if (sent) {
@@ -208,6 +215,7 @@ export default class SigningSessionService
       signingSessions: resultingSigningSessions,
       sentEmails,
       failedEmails,
+      deliveries,
     };
   }
 }

--- a/backend/src/services/modules/signing-sessions/routes.ts
+++ b/backend/src/services/modules/signing-sessions/routes.ts
@@ -16,7 +16,7 @@ import Clients, {
 } from "#src/services/clients/entities/clients";
 import _ from "lodash";
 import { generatePdf } from "../invoices/services/generate-pdf";
-import { recordEmailSendResult } from "../invoices/services/email-send-result";
+import { scheduleEmailSendResultCheck } from "../invoices/services/email-send-result";
 import InternalAdapter from "./adapters/internal/internal";
 import {
   SigningSessions,
@@ -188,7 +188,7 @@ export default (router: Router) => {
       const ctx = Ctx.get(req)!.context;
       if (!req.body.recipients) throw new Error("Recipients are required");
 
-      const { signingSessions, sentEmails, failedEmails } =
+      const { signingSessions, sentEmails, deliveries } =
         await Services.SignatureSessions.createSigningSessions(
           ctx,
           req.params.id,
@@ -236,9 +236,17 @@ export default (router: Router) => {
         });
       }
 
-      // Enregistrer le problème d'envoi (timeline + notification + tag sur le
-      // document) en différenciant l'échec total de l'envoi partiel.
-      await recordEmailSendResult(ctx, invoice, sentEmails, failedEmails);
+      // Les emails sont partis sans bloquer la requête ; le transport remonte
+      // son résultat de façon asynchrone dans `deliveries`. On vérifie l'état
+      // d'envoi après un délai et on enregistre alors le problème éventuel
+      // (timeline + notification + tag sur le document), en différenciant
+      // l'échec total de l'envoi partiel.
+      scheduleEmailSendResultCheck(
+        ctx,
+        invoice,
+        req.body.recipients as Recipient[],
+        deliveries
+      );
 
       res.json(signingSessions);
     }

--- a/frontend/src/molecules/timeline/events.tsx
+++ b/frontend/src/molecules/timeline/events.tsx
@@ -22,8 +22,11 @@ export const Event = ({ id }: { id: string }) => {
         i18nKey="timelines.events.invoice_sent.content"
         components={[
           <>
-            {metadata.recipients.map(({ email }) => (
-              <Link href={"mailto:" + email}>{email}</Link>
+            {metadata.recipients.map(({ email }, index) => (
+              <span key={email}>
+                {index > 0 ? ", " : ""}
+                <Link href={"mailto:" + email}>{email}</Link>
+              </span>
             ))}
           </>,
         ]}
@@ -40,14 +43,20 @@ export const Event = ({ id }: { id: string }) => {
         i18nKey="timelines.events.quote_sent.content"
         components={[
           <>
-            {signers.map(({ email }) => (
-              <Link href={"mailto:" + email}>{email}</Link>
+            {signers.map(({ email }, index) => (
+              <span key={email}>
+                {index > 0 ? ", " : ""}
+                <Link href={"mailto:" + email}>{email}</Link>
+              </span>
             ))}
           </>,
           <span className={viewers?.length ? "" : "hidden"}>
             {t("timelines.events.quote_sent.content_viewers")}{" "}
-            {viewers.map(({ email }) => (
-              <Link href={"mailto:" + email}>{email}</Link>
+            {viewers.map(({ email }, index) => (
+              <span key={email}>
+                {index > 0 ? ", " : ""}
+                <Link href={"mailto:" + email}>{email}</Link>
+              </span>
             ))}
           </span>,
         ]}


### PR DESCRIPTION
The quote_sent and invoice_sent timeline events rendered recipient
emails back-to-back with no delimiter, so multiple addresses appeared
concatenated (e.g. a@x.comb@y.com). Render each email in its own span
with a comma separator, matching the smtp_failed event rendering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BSCbY6pudpESbJJeVfvd27