### PR TITLE
feat(invoices): tri-state email delivery indicator (sent/received/fai…

### DIFF
--- a/backend/src/services/modules/invoices/services/email-send-result.spec.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.spec.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 
 const update = jest.fn();
-const getService = jest.fn(async () => ({ update }));
+const selectOne = jest.fn();
+const getService = jest.fn(async () => ({ update, selectOne }));
 const createEvent = jest.fn();
 
 jest.mock("#src/platform/index", () => ({
   __esModule: true,
-  default: { Db: { getService } },
+  default: { Db: { getService }, LoggerDb: { get: () => ({ error: jest.fn() }) } },
 }));
 
 jest.mock("#src/services/index", () => ({
@@ -15,6 +16,8 @@ jest.mock("#src/services/index", () => ({
 }));
 
 import {
+  markEmailReceived,
+  markEmailSent,
   recordEmailSendResult,
   scheduleEmailSendResultCheck,
 } from "./email-send-result";
@@ -26,17 +29,18 @@ const invoice = (extra: any = {}) =>
 describe("recordEmailSendResult", () => {
   beforeEach(() => {
     update.mockReset();
+    selectOne.mockReset();
     createEvent.mockReset();
     getService.mockClear();
   });
 
-  test("does nothing when everything was sent and no previous flag", async () => {
+  test("does nothing when everything was sent", async () => {
     await recordEmailSendResult(ctx, invoice(), ["a@b.com"], []);
     expect(createEvent).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
   });
 
-  test("clears a previous flag once the send finally goes through", async () => {
+  test("does nothing on success even if a previous flag exists (handled elsewhere)", async () => {
     await recordEmailSendResult(
       ctx,
       invoice({ state_details: { email_status: "failed" } }),
@@ -44,10 +48,7 @@ describe("recordEmailSendResult", () => {
       []
     );
     expect(createEvent).not.toHaveBeenCalled();
-    expect(update).toHaveBeenCalledTimes(1);
-    const payload = update.mock.calls[0][3] as any;
-    expect(payload.state_details.email_status).toBe("");
-    expect(payload.state_details.email_failed_recipients).toEqual([]);
+    expect(update).not.toHaveBeenCalled();
   });
 
   test("records a TOTAL failure when every recipient was rejected", async () => {
@@ -130,6 +131,63 @@ describe("scheduleEmailSendResultCheck", () => {
     await jest.advanceTimersByTimeAsync(1000);
 
     expect(createEvent).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe("markEmailSent", () => {
+  beforeEach(() => {
+    update.mockReset();
+    getService.mockClear();
+  });
+
+  test("flags the document as 'sent'", async () => {
+    await markEmailSent(ctx, invoice());
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][3] as any;
+    expect(payload.state_details.email_status).toBe("sent");
+  });
+
+  test("never downgrades a 'received' confirmation", async () => {
+    await markEmailSent(ctx, invoice({ state_details: { email_status: "received" } }));
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe("markEmailReceived", () => {
+  beforeEach(() => {
+    update.mockReset();
+    selectOne.mockReset();
+    getService.mockClear();
+  });
+
+  test.each([[""], ["sent"]])(
+    "flags 'received' when current status is %p",
+    async (current) => {
+      selectOne.mockResolvedValue(
+        invoice({ state_details: { email_status: current } }) as never
+      );
+      await markEmailReceived(ctx, "inv-1");
+      expect(update).toHaveBeenCalledTimes(1);
+      const payload = update.mock.calls[0][3] as any;
+      expect(payload.state_details.email_status).toBe("received");
+    }
+  );
+
+  test.each([["failed"], ["partial"], ["received"]])(
+    "does not override a %p status",
+    async (current) => {
+      selectOne.mockResolvedValue(
+        invoice({ state_details: { email_status: current } }) as never
+      );
+      await markEmailReceived(ctx, "inv-1");
+      expect(update).not.toHaveBeenCalled();
+    }
+  );
+
+  test("does nothing when the document is not found", async () => {
+    selectOne.mockResolvedValue(null as never);
+    await markEmailReceived(ctx, "missing");
     expect(update).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/modules/invoices/services/email-send-result.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.ts
@@ -13,18 +13,64 @@ import Invoices, { InvoicesDefinition } from "../entities/invoices";
 export const EMAIL_SEND_RESULT_CHECK_DELAY_MS = 30_000;
 
 /**
+ * Optimistically flags a document as "sent" (blue indicator) right after an
+ * email is dispatched — before we know whether it was delivered. Never
+ * downgrades a "received" confirmation that may already be set.
+ */
+export const markEmailSent = async (ctx: Context, invoice: Invoices) => {
+  if (invoice.state_details?.email_status === "received") return;
+
+  const db = await Framework.Db.getService();
+  await db.update<Invoices>(
+    ctx,
+    InvoicesDefinition.name,
+    { id: invoice.id, client_id: invoice.client_id },
+    { state_details: { email_status: "sent", email_failed_recipients: [] } }
+  );
+};
+
+/**
+ * Flags a document as "received" (green indicator): a mail client fetched the
+ * tracking pixel, or the recipient opened the signing link. Both prove the
+ * message reached the recipient's mailbox (Apple MPP only pre-fetches delivered
+ * messages) — not that a human opened it.
+ *
+ * Resolves the document by id (called from public/untenanted endpoints) and
+ * never overrides a confirmed send failure, which stays actionable.
+ */
+export const markEmailReceived = async (ctx: Context, invoiceId: string) => {
+  const db = await Framework.Db.getService();
+
+  const invoice = await db.selectOne<Invoices>(
+    { ...ctx, role: "SYSTEM" },
+    InvoicesDefinition.name,
+    { id: invoiceId }
+  );
+  if (!invoice) return;
+
+  const status = invoice.state_details?.email_status;
+  if (status === "received" || status === "failed" || status === "partial") {
+    return;
+  }
+
+  await db.update<Invoices>(
+    { ...ctx, client_id: invoice.client_id, role: "SYSTEM" },
+    InvoicesDefinition.name,
+    { id: invoice.id, client_id: invoice.client_id },
+    { state_details: { email_status: "received", email_failed_recipients: [] } }
+  );
+};
+
+/**
  * Records the outcome of an email send attempt for a document.
  *
- * When at least one recipient was rejected by the mail server it:
- *  - adds an event to the document timeline (and, through `createEvent`, a
- *    notification for the subscribed users), differentiating a TOTAL failure
- *    (no recipient received the document) from a PARTIAL send (some recipients
- *    got it, some were rejected);
- *  - flags the document with a "problème d'envoi" detail on `state_details` so a
- *    tag can be shown on the document itself.
- *
- * When every recipient received the document it clears any previous
- * send-problem flag (the send finally went through).
+ * Success is handled elsewhere — optimistically by `markEmailSent` at send
+ * time, then confirmed by `markEmailReceived` (tracking pixel / signing view) —
+ * so this function only has to flag a CONFIRMED rejection: it adds a timeline
+ * event (and, through `createEvent`, a notification for subscribed users),
+ * differentiating a TOTAL failure (no recipient received the document) from a
+ * PARTIAL send, and flags the document via `state_details` so the red indicator
+ * can be shown.
  */
 export const recordEmailSendResult = async (
   ctx: Context,
@@ -32,21 +78,9 @@ export const recordEmailSendResult = async (
   sentEmails: string[],
   failedEmails: string[]
 ) => {
+  if (failedEmails.length === 0) return;
+
   const db = await Framework.Db.getService();
-
-  if (failedEmails.length === 0) {
-    // Everything went through: clear a previous send-problem flag if any.
-    if (invoice.state_details?.email_status) {
-      await db.update<Invoices>(
-        ctx,
-        InvoicesDefinition.name,
-        { id: invoice.id, client_id: invoice.client_id },
-        { state_details: { email_status: "", email_failed_recipients: [] } }
-      );
-    }
-    return;
-  }
-
   const partial = sentEmails.length > 0;
 
   // Timeline event + notification (createEvent fans out to notifyUsers because

--- a/backend/src/services/modules/signing-sessions/routes.ts
+++ b/backend/src/services/modules/signing-sessions/routes.ts
@@ -16,7 +16,11 @@ import Clients, {
 } from "#src/services/clients/entities/clients";
 import _ from "lodash";
 import { generatePdf } from "../invoices/services/generate-pdf";
-import { scheduleEmailSendResultCheck } from "../invoices/services/email-send-result";
+import {
+  markEmailReceived,
+  markEmailSent,
+  scheduleEmailSendResultCheck,
+} from "../invoices/services/email-send-result";
 import InternalAdapter from "./adapters/internal/internal";
 import {
   SigningSessions,
@@ -236,6 +240,11 @@ export default (router: Router) => {
         });
       }
 
+      // Indicateur "envoyé" (bleu) tout de suite, de façon optimiste.
+      if (sentRecipients.length > 0) {
+        await markEmailSent(ctx, invoice);
+      }
+
       // Les emails sont partis sans bloquer la requête ; le transport remonte
       // son résultat de façon asynchrone dans `deliveries`. On vérifie l'état
       // d'envoi après un délai et on enregistre alors le problème éventuel
@@ -251,6 +260,35 @@ export default (router: Router) => {
       res.json(signingSessions);
     }
   );
+
+  // Public open-tracking pixel embedded in the sent email. When a mail client
+  // fetches it, the document is flagged "received" (green indicator). A hit
+  // proves the message reached the recipient's mailbox — not that a human
+  // opened it (Apple MPP pre-fetches). Always returns a 1x1 transparent GIF,
+  // even on error, so mail clients never show a broken image.
+  router.get("/track/:invoiceId/pixel.gif", async (req, res) => {
+    try {
+      const ctx = Ctx.get(req)!.context;
+      await markEmailReceived(ctx, req.params.invoiceId);
+    } catch (e: any) {
+      platform.LoggerDb.get("signing-sessions").error(
+        null,
+        "Tracking pixel failed",
+        e
+      );
+    }
+
+    // 1x1 transparent GIF.
+    const pixel = Buffer.from(
+      "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+      "base64"
+    );
+    res.set("Content-Type", "image/gif");
+    res.set("Content-Length", String(pixel.length));
+    res.set("Cache-Control", "no-store, no-cache, must-revalidate, private");
+    res.set("Pragma", "no-cache");
+    res.send(pixel);
+  });
 
   router.get("/:id", async (req, res) => {
     const db = await platform.Db.getService();

--- a/backend/src/services/modules/signing-sessions/services/create.ts
+++ b/backend/src/services/modules/signing-sessions/services/create.ts
@@ -7,6 +7,7 @@ import {
   SigningSessions,
   SigningSessionsDefinition,
 } from "../entities/signing-session";
+import { markEmailReceived } from "../../invoices/services/email-send-result";
 import { onSigningSessionCancelled } from "../triggers/on-cancelled";
 import { onSigningSessionSigned } from "../triggers/on-signed";
 
@@ -78,6 +79,16 @@ export const updateSigningSession = async (ctx, session: SigningSessions) => {
 
   if (updatedSession.state === "signed" && previousSession.state !== "signed") {
     await onSigningSessionSigned(ctx, updatedSession);
+  }
+
+  // Opening the signing link (viewed) or signing proves the recipient received
+  // the email → flag the document "received" (green). This is a first-party,
+  // reliable signal, unlike the tracking pixel.
+  if (
+    ["viewed", "signed"].includes(updatedSession.state) &&
+    !["viewed", "signed"].includes(previousSession.state)
+  ) {
+    await markEmailReceived(ctx, updatedSession.invoice_id);
   }
 
   return updatedSession;

--- a/backend/src/services/modules/signing-sessions/services/utils.ts
+++ b/backend/src/services/modules/signing-sessions/services/utils.ts
@@ -122,6 +122,17 @@ export const generateEmailMessageToRecipient = async (
     },
   });
 
+  // Open-tracking pixel: a fetch flags the document as "received" (green). Only
+  // on the initial send, and only when we have a document id to attribute it to.
+  if (action === "sent" && invoice.id) {
+    const pixelUrl = `${config
+      .get<string>("server.domain")
+      .replace(/\/$/, "")}/api/signing-sessions/v1/track/${
+      invoice.id
+    }/pixel.gif`;
+    message += `<img src="${pixelUrl}" width="1" height="1" alt="" style="border:0;width:1px;height:1px;max-height:1px;max-width:1px;overflow:hidden" />`;
+  }
+
   return { message, subject, htmlLogo };
 };
 

--- a/frontend/src/features/invoices/components/email-status-icon.tsx
+++ b/frontend/src/features/invoices/components/email-status-icon.tsx
@@ -1,0 +1,107 @@
+import { Badge, Tooltip } from "@radix-ui/themes";
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  PaperAirplaneIcon,
+} from "@heroicons/react/16/solid";
+import { Invoices } from "../types/types";
+
+const failedTooltip = (
+  stateDetails: Invoices["state_details"],
+  status: "partial" | "failed"
+) => {
+  const failed = stateDetails?.email_failed_recipients || [];
+  return status === "partial"
+    ? "Le document n'a pas pu être envoyé à certains destinataires : " +
+        failed.join(", ")
+    : "Le document n'a pas pu être envoyé : " + failed.join(", ");
+};
+
+/**
+ * Small tri-state indicator for the email delivery status of a document:
+ *   green  "received" -> reached the recipient's mailbox (pixel fetched, or the
+ *                        signing link was opened). Not "opened by a human".
+ *   blue   "sent"     -> sent, delivery not yet confirmed.
+ *   red    "partial"/"failed" -> a confirmed send failure.
+ * Renders nothing when nothing has been sent yet.
+ */
+export const EmailStatusIcon = ({
+  stateDetails,
+  className = "h-4 w-4 shrink-0",
+}: {
+  stateDetails?: Invoices["state_details"];
+  className?: string;
+}) => {
+  const status = stateDetails?.email_status;
+  if (!status) return null;
+
+  if (status === "received") {
+    return (
+      <Tooltip content="Arrivé dans la boîte du destinataire">
+        <CheckCircleIcon className={className + " text-green-500"} />
+      </Tooltip>
+    );
+  }
+
+  if (status === "sent") {
+    return (
+      <Tooltip content="Envoyé — réception pas encore confirmée">
+        <PaperAirplaneIcon className={className + " text-blue-500"} />
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip content={failedTooltip(stateDetails, status)}>
+      <ExclamationCircleIcon className={className + " text-red-500"} />
+    </Tooltip>
+  );
+};
+
+/**
+ * Same tri-state as EmailStatusIcon, rendered as a labelled Radix Badge for
+ * detail pages (where a bit of text alongside the icon reads better).
+ */
+export const EmailStatusBadge = ({
+  stateDetails,
+  className = "ml-2",
+}: {
+  stateDetails?: Invoices["state_details"];
+  className?: string;
+}) => {
+  const status = stateDetails?.email_status;
+  if (!status) return null;
+
+  const iconClassName = "h-3 w-3 inline-block mr-1 -mt-0.5";
+
+  if (status === "received") {
+    return (
+      <Tooltip content="Arrivé dans la boîte du destinataire">
+        <Badge className={className} variant="soft" color="green" size="2">
+          <CheckCircleIcon className={iconClassName} />
+          Reçu
+        </Badge>
+      </Tooltip>
+    );
+  }
+
+  if (status === "sent") {
+    return (
+      <Tooltip content="Envoyé — réception pas encore confirmée">
+        <Badge className={className} variant="soft" color="blue" size="2">
+          <PaperAirplaneIcon className={iconClassName} />
+          Envoyé
+        </Badge>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip content={failedTooltip(stateDetails, status)}>
+      <Badge className={className} variant="soft" color="red" size="2">
+        <ExclamationCircleIcon className={iconClassName} />
+        {status === "partial" ? "Envoi partiel" : "Problème d'envoi"}
+      </Badge>
+    </Tooltip>
+  );
+};

--- a/frontend/src/features/invoices/configuration.tsx
+++ b/frontend/src/features/invoices/configuration.tsx
@@ -16,11 +16,11 @@ import { getRestApiClient } from "@features/utils/rest/hooks/use-rest";
 import {
   ArrowPathIcon,
   CheckIcon,
-  ExclamationCircleIcon,
   RectangleStackIcon,
 } from "@heroicons/react/16/solid";
 import { Column } from "@molecules/table/table";
-import { Badge, Tooltip } from "@radix-ui/themes";
+import { Badge } from "@radix-ui/themes";
+import { EmailStatusIcon } from "./components/email-status-icon";
 import {
   computePricesFromInvoice,
   isDeliveryLate,
@@ -250,23 +250,7 @@ export const InvoicesColumns: Column<Invoices>[] = [
     orderBy: "state_order",
     render: (invoice) => (
       <div className="flex flex-row items-center space-x-1">
-        {!!invoice.state_details?.email_status && (
-          <Tooltip
-            content={
-              invoice.state_details.email_status === "partial"
-                ? "Le document n'a pas pu être envoyé à certains destinataires : " +
-                  (invoice.state_details.email_failed_recipients || []).join(
-                    ", ",
-                  )
-                : "Le document n'a pas pu être envoyé : " +
-                  (invoice.state_details.email_failed_recipients || []).join(
-                    ", ",
-                  )
-            }
-          >
-            <ExclamationCircleIcon className="h-4 w-4 shrink-0 text-red-500" />
-          </Tooltip>
-        )}
+        <EmailStatusIcon stateDetails={invoice.state_details} />
         <InvoiceStatus
           size="sm"
           readonly

--- a/frontend/src/features/invoices/types/types.ts
+++ b/frontend/src/features/invoices/types/types.ts
@@ -33,7 +33,7 @@ export type Invoices = RestEntity & {
   // Extra details tied to the current state (e.g. an email send problem).
   // Reset by the backend whenever the state changes.
   state_details?: {
-    email_status: "" | "partial" | "failed";
+    email_status: "" | "sent" | "received" | "partial" | "failed";
     email_failed_recipients: string[];
   } | null;
 

--- a/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
+++ b/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
@@ -18,6 +18,7 @@ import { Clients } from "@features/clients/types/clients";
 import { useContact, useContacts } from "@features/contacts/hooks/use-contacts";
 import { Contacts } from "@features/contacts/types/types";
 import { useViewWithCtrlK } from "@features/ctrlk/use-edit-from-ctrlk";
+import { EmailStatusBadge } from "@features/invoices/components/email-status-icon";
 import { InvoicesFieldsNames } from "@features/invoices/configuration";
 import { useEInvoicesReady } from "@features/invoices/hooks/use-e-invoices-ready";
 import { useInvoice, useInvoices } from "@features/invoices/hooks/use-invoices";
@@ -375,33 +376,7 @@ export const InvoicesDetailsPage = ({
                     Tacite reconduction
                   </Badge>
                 )}
-              {!!draft.state_details?.email_status && (
-                <Tooltip
-                  content={
-                    draft.state_details.email_status === "partial"
-                      ? "Le document n'a pas pu être envoyé à certains destinataires : " +
-                        (
-                          draft.state_details.email_failed_recipients || []
-                        ).join(", ")
-                      : "Le document n'a pas pu être envoyé : " +
-                        (
-                          draft.state_details.email_failed_recipients || []
-                        ).join(", ")
-                  }
-                >
-                  <Badge
-                    className="ml-2"
-                    variant="soft"
-                    color="red"
-                    size="2"
-                  >
-                    <ExclamationCircleIcon className="h-3 w-3 inline-block mr-1 -mt-0.5" />
-                    {draft.state_details.email_status === "partial"
-                      ? "Envoi partiel"
-                      : "Problème d'envoi"}
-                  </Badge>
-                </Tooltip>
-              )}
+              <EmailStatusBadge stateDetails={draft.state_details} />
               <div className="grow" />
               {draft.type === "invoices" && (
                 <TagPaymentCompletion invoice={draft} />

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -27,10 +27,15 @@ export class InvoiceStateDetails {
   // details in the future.
 
   // Email delivery status of the last send attempt done in the current state:
-  //   ""        -> nothing to report
-  //   "partial" -> at least one recipient received the email, some were rejected
-  //   "failed"  -> every recipient was rejected
-  email_status: "" | "partial" | "failed" = "";
+  //   ""         -> nothing sent yet (no indicator)
+  //   "sent"     -> sent, delivery not yet confirmed (blue)
+  //   "received" -> confirmed delivered to the recipient's mailbox — a mail
+  //                 client fetched the tracking pixel, or the recipient opened
+  //                 the signing link (green). Not "opened by a human": Apple
+  //                 Mail Privacy Protection pre-fetches delivered messages.
+  //   "partial"  -> at least one recipient received the email, some were rejected (red)
+  //   "failed"   -> every recipient was rejected (red)
+  email_status: "" | "sent" | "received" | "partial" | "failed" = "";
   // Recipients rejected by the mail server on the last send attempt.
   email_failed_recipients = ["string"];
 }


### PR DESCRIPTION
…led)

Adds a small status icon next to a document's state showing where its last email got to, replacing the failure-only red icon:
  - green  'received' -> reached the recipient's mailbox
  - blue   'sent'     -> sent, delivery not yet confirmed
  - red    'partial'/'failed' -> a confirmed send failure

Backend: extend state_details.email_status with 'sent' and 'received'. markEmailSent flags 'sent' optimistically at send time; recordEmailSendResult now only flags confirmed failures. 'received' is set by two signals:
  - an open-tracking pixel embedded in the sent email (public endpoint returning a 1x1 GIF) — a fetch proves the message reached the mailbox (Apple MPP only pre-fetches delivered mail); it does not prove a human opened it, hence the wording 'reçu / arrivé', never 'ouvert';
  - the recipient opening the signing link (session viewed/signed), a more reliable first-party signal.

Frontend: shared EmailStatusIcon (list) and EmailStatusBadge (detail) with hover tooltips.


Claude-Session: https://claude.ai/code/session_01BSCbY6pudpESbJJeVfvd27