### PR TITLE
Refactor email delivery status to per-recipient tracking

### DIFF
--- a/backend/src/services/modules/invoices/services/email-send-result.spec.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.spec.ts
@@ -175,7 +175,7 @@ describe("markEmailReceived", () => {
   );
 
   test.each([["failed"], ["partial"], ["received"]])(
-    "does not override a %p status",
+    "does not override a %p status (no recipient given)",
     async (current) => {
       selectOne.mockResolvedValue(
         invoice({ state_details: { email_status: current } }) as never
@@ -188,6 +188,67 @@ describe("markEmailReceived", () => {
   test("does nothing when the document is not found", async () => {
     selectOne.mockResolvedValue(null as never);
     await markEmailReceived(ctx, "missing");
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("records a specific recipient as delivery-confirmed", async () => {
+    selectOne.mockResolvedValue(
+      invoice({ state_details: { email_status: "sent" } }) as never
+    );
+    await markEmailReceived(ctx, "inv-1", "a@b.com");
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][3] as any;
+    expect(payload.state_details.email_status).toBe("received");
+    expect(payload.state_details.email_received_recipients).toEqual(["a@b.com"]);
+  });
+
+  test("adds a recipient without dropping the ones already confirmed", async () => {
+    selectOne.mockResolvedValue(
+      invoice({
+        state_details: {
+          email_status: "received",
+          email_received_recipients: ["a@b.com"],
+        },
+      }) as never
+    );
+    await markEmailReceived(ctx, "inv-1", "c@d.com");
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][3] as any;
+    expect(payload.state_details.email_received_recipients).toEqual([
+      "a@b.com",
+      "c@d.com",
+    ]);
+  });
+
+  test("records a recipient without downgrading a partial failure", async () => {
+    selectOne.mockResolvedValue(
+      invoice({
+        state_details: {
+          email_status: "partial",
+          email_failed_recipients: ["x@y.com"],
+        },
+      }) as never
+    );
+    await markEmailReceived(ctx, "inv-1", "a@b.com");
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][3] as any;
+    // Failure stays actionable...
+    expect(payload.state_details.email_status).toBe("partial");
+    expect(payload.state_details.email_failed_recipients).toEqual(["x@y.com"]);
+    // ...but the confirmed recipient is still recorded.
+    expect(payload.state_details.email_received_recipients).toEqual(["a@b.com"]);
+  });
+
+  test("does not write when the recipient is already recorded", async () => {
+    selectOne.mockResolvedValue(
+      invoice({
+        state_details: {
+          email_status: "received",
+          email_received_recipients: ["a@b.com"],
+        },
+      }) as never
+    );
+    await markEmailReceived(ctx, "inv-1", "a@b.com");
     expect(update).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/modules/invoices/services/email-send-result.ts
+++ b/backend/src/services/modules/invoices/services/email-send-result.ts
@@ -2,6 +2,7 @@ import Framework from "#src/platform/index";
 import type { EmailSendResult } from "#src/platform/push-email/api";
 import Services from "#src/services/index";
 import { Context } from "#src/types";
+import _ from "lodash";
 import Invoices, { InvoicesDefinition } from "../entities/invoices";
 
 /**
@@ -25,20 +26,37 @@ export const markEmailSent = async (ctx: Context, invoice: Invoices) => {
     ctx,
     InvoicesDefinition.name,
     { id: invoice.id, client_id: invoice.client_id },
-    { state_details: { email_status: "sent", email_failed_recipients: [] } }
+    {
+      state_details: {
+        email_status: "sent",
+        email_failed_recipients: [],
+        // A fresh send starts a new delivery-tracking round.
+        email_received_recipients: [],
+      },
+    }
   );
 };
 
 /**
- * Flags a document as "received" (green indicator): a mail client fetched the
+ * Flags delivery as confirmed ("received" — green): a mail client fetched the
  * tracking pixel, or the recipient opened the signing link. Both prove the
  * message reached the recipient's mailbox (Apple MPP only pre-fetches delivered
  * messages) — not that a human opened it.
  *
- * Resolves the document by id (called from public/untenanted endpoints) and
- * never overrides a confirmed send failure, which stays actionable.
+ * When `recipientEmail` is given, the confirmation is recorded for that specific
+ * recipient (added to `email_received_recipients`); this is what drives the
+ * per-recipient dots in the timeline. The document-level `email_status` is also
+ * bumped to "received" as a coarse aggregate for the compact list indicator,
+ * but a confirmed send failure ("failed"/"partial") is never downgraded — it
+ * stays actionable.
+ *
+ * Resolves the document by id (called from public/untenanted endpoints).
  */
-export const markEmailReceived = async (ctx: Context, invoiceId: string) => {
+export const markEmailReceived = async (
+  ctx: Context,
+  invoiceId: string,
+  recipientEmail?: string
+) => {
   const db = await Framework.Db.getService();
 
   const invoice = await db.selectOne<Invoices>(
@@ -48,8 +66,20 @@ export const markEmailReceived = async (ctx: Context, invoiceId: string) => {
   );
   if (!invoice) return;
 
-  const status = invoice.state_details?.email_status;
-  if (status === "received" || status === "failed" || status === "partial") {
+  const details = invoice.state_details;
+  const status = details?.email_status;
+
+  const previousReceived = details?.email_received_recipients || [];
+  const nextReceived = recipientEmail
+    ? _.uniq([...previousReceived, recipientEmail])
+    : previousReceived;
+
+  // Keep a confirmed failure actionable; otherwise reflect the confirmation.
+  const nextStatus =
+    status === "failed" || status === "partial" ? status : "received";
+
+  // Nothing changed (no new recipient, status already up to date): skip write.
+  if (nextStatus === status && nextReceived.length === previousReceived.length) {
     return;
   }
 
@@ -57,7 +87,13 @@ export const markEmailReceived = async (ctx: Context, invoiceId: string) => {
     { ...ctx, client_id: invoice.client_id, role: "SYSTEM" },
     InvoicesDefinition.name,
     { id: invoice.id, client_id: invoice.client_id },
-    { state_details: { email_status: "received", email_failed_recipients: [] } }
+    {
+      state_details: {
+        email_status: nextStatus,
+        email_failed_recipients: details?.email_failed_recipients || [],
+        email_received_recipients: nextReceived,
+      },
+    }
   );
 };
 
@@ -103,7 +139,9 @@ export const recordEmailSendResult = async (
     reactions: [],
   });
 
-  // Flag the document so a "problème d'envoi" tag can be displayed.
+  // Flag the document so a "problème d'envoi" tag can be displayed. Preserve any
+  // per-recipient delivery confirmations already recorded (state_details is
+  // replaced wholesale, not merged).
   await db.update<Invoices>(
     ctx,
     InvoicesDefinition.name,
@@ -112,6 +150,8 @@ export const recordEmailSendResult = async (
       state_details: {
         email_status: partial ? "partial" : "failed",
         email_failed_recipients: failedEmails,
+        email_received_recipients:
+          invoice.state_details?.email_received_recipients || [],
       },
     }
   );

--- a/backend/src/services/modules/invoices/triggers/upsert-hook.ts
+++ b/backend/src/services/modules/invoices/triggers/upsert-hook.ts
@@ -82,6 +82,7 @@ export const setUpsertHook = () =>
         updated.state_details = {
           email_status: "",
           email_failed_recipients: [],
+          email_received_recipients: [],
         };
       }
 

--- a/backend/src/services/modules/signing-sessions/routes.ts
+++ b/backend/src/services/modules/signing-sessions/routes.ts
@@ -261,11 +261,53 @@ export default (router: Router) => {
     }
   );
 
-  // Public open-tracking pixel embedded in the sent email. When a mail client
-  // fetches it, the document is flagged "received" (green indicator). A hit
-  // proves the message reached the recipient's mailbox — not that a human
-  // opened it (Apple MPP pre-fetches). Always returns a 1x1 transparent GIF,
-  // even on error, so mail clients never show a broken image.
+  // Always answers with a 1x1 transparent GIF, even on error, so mail clients
+  // never show a broken image.
+  const sendTrackingPixel = (res: any) => {
+    const pixel = Buffer.from(
+      "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+      "base64"
+    );
+    res.set("Content-Type", "image/gif");
+    res.set("Content-Length", String(pixel.length));
+    res.set("Cache-Control", "no-store, no-cache, must-revalidate, private");
+    res.set("Pragma", "no-cache");
+    res.send(pixel);
+  };
+
+  // Public open-tracking pixel embedded in the sent email, attributed to a
+  // specific recipient via their signing-session id. When a mail client fetches
+  // it, that recipient is flagged as delivery-confirmed (green dot in the
+  // timeline). A hit proves the message reached the recipient's mailbox — not
+  // that a human opened it (Apple MPP pre-fetches).
+  router.get("/track/:invoiceId/:sessionId/pixel.gif", async (req, res) => {
+    try {
+      const ctx = Ctx.get(req)!.context;
+      const db = await platform.Db.getService();
+      const session = await db.selectOne<SigningSessions>(
+        { ...ctx, role: "SYSTEM" },
+        SigningSessionsDefinition.name,
+        { id: req.params.sessionId, invoice_id: req.params.invoiceId }
+      );
+      await markEmailReceived(
+        ctx,
+        req.params.invoiceId,
+        session?.recipient_email
+      );
+    } catch (e: any) {
+      platform.LoggerDb.get("signing-sessions").error(
+        null,
+        "Tracking pixel failed",
+        e
+      );
+    }
+
+    sendTrackingPixel(res);
+  });
+
+  // Backward-compatible document-level pixel (emails sent before per-recipient
+  // tracking carry this URL). Flags the document "received" without attributing
+  // it to a specific recipient.
   router.get("/track/:invoiceId/pixel.gif", async (req, res) => {
     try {
       const ctx = Ctx.get(req)!.context;
@@ -278,16 +320,7 @@ export default (router: Router) => {
       );
     }
 
-    // 1x1 transparent GIF.
-    const pixel = Buffer.from(
-      "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-      "base64"
-    );
-    res.set("Content-Type", "image/gif");
-    res.set("Content-Length", String(pixel.length));
-    res.set("Cache-Control", "no-store, no-cache, must-revalidate, private");
-    res.set("Pragma", "no-cache");
-    res.send(pixel);
+    sendTrackingPixel(res);
   });
 
   router.get("/:id", async (req, res) => {

--- a/backend/src/services/modules/signing-sessions/services/create.ts
+++ b/backend/src/services/modules/signing-sessions/services/create.ts
@@ -88,7 +88,11 @@ export const updateSigningSession = async (ctx, session: SigningSessions) => {
     ["viewed", "signed"].includes(updatedSession.state) &&
     !["viewed", "signed"].includes(previousSession.state)
   ) {
-    await markEmailReceived(ctx, updatedSession.invoice_id);
+    await markEmailReceived(
+      ctx,
+      updatedSession.invoice_id,
+      updatedSession.recipient_email
+    );
   }
 
   return updatedSession;

--- a/backend/src/services/modules/signing-sessions/services/utils.ts
+++ b/backend/src/services/modules/signing-sessions/services/utils.ts
@@ -122,14 +122,20 @@ export const generateEmailMessageToRecipient = async (
     },
   });
 
-  // Open-tracking pixel: a fetch flags the document as "received" (green). Only
-  // on the initial send, and only when we have a document id to attribute it to.
+  // Open-tracking pixel: a fetch flags delivery as confirmed ("received",
+  // green). Only on the initial send, and only when we have a document id to
+  // attribute it to. The recipient's signing-session id is embedded so the hit
+  // is attributed to that specific recipient (per-recipient dot in the
+  // timeline). It is an opaque id, not the email — no address is leaked in the
+  // URL. A fetch reaches the recipient's mailbox but does not prove a human
+  // opened it (Apple MPP pre-fetches).
   if (action === "sent" && invoice.id) {
-    const pixelUrl = `${config
+    const base = `${config
       .get<string>("server.domain")
-      .replace(/\/$/, "")}/api/signing-sessions/v1/track/${
-      invoice.id
-    }/pixel.gif`;
+      .replace(/\/$/, "")}/api/signing-sessions/v1/track/${invoice.id}`;
+    const pixelUrl = signingSession?.id
+      ? `${base}/${signingSession.id}/pixel.gif`
+      : `${base}/pixel.gif`;
     message += `<img src="${pixelUrl}" width="1" height="1" alt="" style="border:0;width:1px;height:1px;max-height:1px;max-width:1px;overflow:hidden" />`;
   }
 

--- a/frontend/src/features/invoices/components/email-status-icon.tsx
+++ b/frontend/src/features/invoices/components/email-status-icon.tsx
@@ -63,11 +63,14 @@ export type RecipientDeliveryStatus = "sent" | "received" | "failed";
 /**
  * Per-recipient delivery status, derived from the document's state_details:
  *   - "failed"   -> this recipient was rejected by the mail server.
- *   - "received" -> the document was confirmed delivered (tracking pixel fetched
- *                   or signing link opened). This is a document-level signal, so
- *                   it colours every non-failed recipient green once confirmed.
+ *   - "received" -> this recipient's delivery was confirmed — their tracking
+ *                   pixel was fetched, or they opened their signing link.
  *   - "sent"     -> sent, delivery not yet confirmed (the default for a
  *                   recipient we haven't heard back about).
+ *
+ * Falls back to the document-level "received" aggregate only for documents sent
+ * before per-recipient tracking existed (no email_received_recipients recorded),
+ * so their dots still turn green.
  */
 export const recipientDeliveryStatus = (
   email: string,
@@ -76,7 +79,11 @@ export const recipientDeliveryStatus = (
   if ((stateDetails?.email_failed_recipients || []).includes(email)) {
     return "failed";
   }
-  if (stateDetails?.email_status === "received") return "received";
+  const received = stateDetails?.email_received_recipients || [];
+  if (received.includes(email)) return "received";
+  if (received.length === 0 && stateDetails?.email_status === "received") {
+    return "received";
+  }
   return "sent";
 };
 

--- a/frontend/src/features/invoices/components/email-status-icon.tsx
+++ b/frontend/src/features/invoices/components/email-status-icon.tsx
@@ -1,4 +1,4 @@
-import { Badge, Tooltip } from "@radix-ui/themes";
+import { Tooltip } from "@radix-ui/themes";
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -58,50 +58,67 @@ export const EmailStatusIcon = ({
   );
 };
 
+export type RecipientDeliveryStatus = "sent" | "received" | "failed";
+
 /**
- * Same tri-state as EmailStatusIcon, rendered as a labelled Radix Badge for
- * detail pages (where a bit of text alongside the icon reads better).
+ * Per-recipient delivery status, derived from the document's state_details:
+ *   - "failed"   -> this recipient was rejected by the mail server.
+ *   - "received" -> the document was confirmed delivered (tracking pixel fetched
+ *                   or signing link opened). This is a document-level signal, so
+ *                   it colours every non-failed recipient green once confirmed.
+ *   - "sent"     -> sent, delivery not yet confirmed (the default for a
+ *                   recipient we haven't heard back about).
  */
-export const EmailStatusBadge = ({
-  stateDetails,
-  className = "ml-2",
+export const recipientDeliveryStatus = (
+  email: string,
+  stateDetails?: Invoices["state_details"]
+): RecipientDeliveryStatus => {
+  if ((stateDetails?.email_failed_recipients || []).includes(email)) {
+    return "failed";
+  }
+  if (stateDetails?.email_status === "received") return "received";
+  return "sent";
+};
+
+const recipientDot: Record<
+  RecipientDeliveryStatus,
+  { color: string; tooltip: string }
+> = {
+  received: {
+    color: "bg-green-500",
+    tooltip: "Arrivé dans la boîte du destinataire",
+  },
+  sent: {
+    color: "bg-blue-500",
+    tooltip: "Envoyé — réception pas encore confirmée",
+  },
+  failed: {
+    color: "bg-red-500",
+    tooltip: "Le document n'a pas pu être envoyé à ce destinataire",
+  },
+};
+
+/**
+ * Small coloured dot shown next to a recipient in the timeline, echoing the
+ * document's email delivery status for that specific recipient.
+ */
+export const RecipientStatusDot = ({
+  status,
+  className = "",
 }: {
-  stateDetails?: Invoices["state_details"];
+  status: RecipientDeliveryStatus;
   className?: string;
 }) => {
-  const status = stateDetails?.email_status;
-  if (!status) return null;
-
-  const iconClassName = "h-3 w-3 inline-block mr-1 -mt-0.5";
-
-  if (status === "received") {
-    return (
-      <Tooltip content="Arrivé dans la boîte du destinataire">
-        <Badge className={className} variant="soft" color="green" size="2">
-          <CheckCircleIcon className={iconClassName} />
-          Reçu
-        </Badge>
-      </Tooltip>
-    );
-  }
-
-  if (status === "sent") {
-    return (
-      <Tooltip content="Envoyé — réception pas encore confirmée">
-        <Badge className={className} variant="soft" color="blue" size="2">
-          <PaperAirplaneIcon className={iconClassName} />
-          Envoyé
-        </Badge>
-      </Tooltip>
-    );
-  }
-
+  const { color, tooltip } = recipientDot[status];
   return (
-    <Tooltip content={failedTooltip(stateDetails, status)}>
-      <Badge className={className} variant="soft" color="red" size="2">
-        <ExclamationCircleIcon className={iconClassName} />
-        {status === "partial" ? "Envoi partiel" : "Problème d'envoi"}
-      </Badge>
+    <Tooltip content={tooltip}>
+      <span
+        className={
+          "inline-block h-2 w-2 rounded-full ml-1 align-middle " +
+          color +
+          (className ? " " + className : "")
+        }
+      />
     </Tooltip>
   );
 };

--- a/frontend/src/features/invoices/types/types.ts
+++ b/frontend/src/features/invoices/types/types.ts
@@ -35,6 +35,7 @@ export type Invoices = RestEntity & {
   state_details?: {
     email_status: "" | "sent" | "received" | "partial" | "failed";
     email_failed_recipients: string[];
+    email_received_recipients?: string[];
   } | null;
 
   // For credit notes or supplier credit note: invoices refunded by this credit note

--- a/frontend/src/molecules/timeline/events.tsx
+++ b/frontend/src/molecules/timeline/events.tsx
@@ -5,6 +5,44 @@ import { Trans, useTranslation } from "react-i18next";
 import { ReactNode } from "react";
 import Link from "@atoms/link";
 import Env from "@config/environment";
+import { useRest } from "@features/utils/rest/hooks/use-rest";
+import { Invoices } from "@features/invoices/types/types";
+import {
+  RecipientStatusDot,
+  recipientDeliveryStatus,
+} from "@features/invoices/components/email-status-icon";
+
+/**
+ * Renders the recipient email list of a "sent" timeline event, each followed by
+ * a small coloured dot echoing that recipient's delivery status (blue sent /
+ * green received / red failed). The status is read from the parent invoice's
+ * state_details. We fetch with `limit: 1` so the query key matches the detail
+ * page's own load and this reads straight from the React Query cache (no extra
+ * request, no invalidation of the open document).
+ */
+const RecipientsWithStatus = ({
+  invoiceId,
+  recipients,
+}: {
+  invoiceId: string;
+  recipients: { email: string }[];
+}) => {
+  const { items } = useRest<Invoices>("invoices", { id: invoiceId, limit: 1 });
+  const invoice = items.data?.list?.[0];
+  return (
+    <>
+      {recipients.map(({ email }, index) => (
+        <span key={email}>
+          {index > 0 ? ", " : ""}
+          <Link href={"mailto:" + email}>{email}</Link>
+          <RecipientStatusDot
+            status={recipientDeliveryStatus(email, invoice?.state_details)}
+          />
+        </span>
+      ))}
+    </>
+  );
+};
 
 export const Event = ({ id }: { id: string }) => {
   const { comment } = useComment(id);
@@ -21,14 +59,10 @@ export const Event = ({ id }: { id: string }) => {
         t={t}
         i18nKey="timelines.events.invoice_sent.content"
         components={[
-          <>
-            {metadata.recipients.map(({ email }, index) => (
-              <span key={email}>
-                {index > 0 ? ", " : ""}
-                <Link href={"mailto:" + email}>{email}</Link>
-              </span>
-            ))}
-          </>,
+          <RecipientsWithStatus
+            invoiceId={comment.item_id}
+            recipients={metadata.recipients}
+          />,
         ]}
       />
     );
@@ -42,22 +76,16 @@ export const Event = ({ id }: { id: string }) => {
         t={t}
         i18nKey="timelines.events.quote_sent.content"
         components={[
-          <>
-            {signers.map(({ email }, index) => (
-              <span key={email}>
-                {index > 0 ? ", " : ""}
-                <Link href={"mailto:" + email}>{email}</Link>
-              </span>
-            ))}
-          </>,
+          <RecipientsWithStatus
+            invoiceId={comment.item_id}
+            recipients={signers}
+          />,
           <span className={viewers?.length ? "" : "hidden"}>
             {t("timelines.events.quote_sent.content_viewers")}{" "}
-            {viewers.map(({ email }, index) => (
-              <span key={email}>
-                {index > 0 ? ", " : ""}
-                <Link href={"mailto:" + email}>{email}</Link>
-              </span>
-            ))}
+            <RecipientsWithStatus
+              invoiceId={comment.item_id}
+              recipients={viewers}
+            />
           </span>,
         ]}
       />

--- a/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
+++ b/frontend/src/views/client/modules/invoices/components/invoices-details.tsx
@@ -18,7 +18,6 @@ import { Clients } from "@features/clients/types/clients";
 import { useContact, useContacts } from "@features/contacts/hooks/use-contacts";
 import { Contacts } from "@features/contacts/types/types";
 import { useViewWithCtrlK } from "@features/ctrlk/use-edit-from-ctrlk";
-import { EmailStatusBadge } from "@features/invoices/components/email-status-icon";
 import { InvoicesFieldsNames } from "@features/invoices/configuration";
 import { useEInvoicesReady } from "@features/invoices/hooks/use-e-invoices-ready";
 import { useInvoice, useInvoices } from "@features/invoices/hooks/use-invoices";
@@ -376,7 +375,6 @@ export const InvoicesDetailsPage = ({
                     Tacite reconduction
                   </Badge>
                 )}
-              <EmailStatusBadge stateDetails={draft.state_details} />
               <div className="grow" />
               {draft.type === "invoices" && (
                 <TagPaymentCompletion invoice={draft} />

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -35,9 +35,17 @@ export class InvoiceStateDetails {
   //                 Mail Privacy Protection pre-fetches delivered messages.
   //   "partial"  -> at least one recipient received the email, some were rejected (red)
   //   "failed"   -> every recipient was rejected (red)
+  //
+  // NB: "received" here is a document-level aggregate (at least one recipient
+  // confirmed) kept for the compact list indicator. Per-recipient delivery is
+  // tracked in email_received_recipients / email_failed_recipients below.
   email_status: "" | "sent" | "received" | "partial" | "failed" = "";
   // Recipients rejected by the mail server on the last send attempt.
   email_failed_recipients = ["string"];
+  // Recipients whose delivery was confirmed on the last send attempt: their
+  // per-recipient tracking pixel was fetched, or they opened their signing
+  // link. Same caveat as "received" above (mailbox reached, not human-opened).
+  email_received_recipients = ["string"];
 }
 
 export class FromSubscription {


### PR DESCRIPTION
## Summary

This PR refactors email delivery status tracking from a document-level badge to per-recipient status indicators. It introduces a new `recipientDeliveryStatus` function that determines delivery status for individual recipients based on the document's `state_details`, and replaces the `EmailStatusBadge` component with a lightweight `RecipientStatusDot` component that displays colored dots next to each recipient in timeline events.

## Key Changes

- **New type and utility function:** Added `RecipientDeliveryStatus` type ("sent" | "received" | "failed") and `recipientDeliveryStatus()` function that evaluates per-recipient status by checking `email_failed_recipients` list and document-level `email_status`
- **Replaced EmailStatusBadge:** Removed the document-level badge component and replaced it with `RecipientStatusDot` — a minimal inline component that renders a colored dot (blue/green/red) with a tooltip
- **Enhanced timeline events:** Updated `RecipientsWithStatus` component in `events.tsx` to fetch the parent invoice's `state_details` via React Query and display delivery status dots next to each recipient email
- **Applied to both invoice and quote timelines:** Both "invoice sent" and "quote sent" timeline events now show per-recipient delivery status indicators
- **Removed unused imports:** Cleaned up `Badge` import from `email-status-icon.tsx` and removed `EmailStatusBadge` import from `invoices-details.tsx`

## Implementation Details

- The `recipientDeliveryStatus()` function prioritizes failed status (checked first), then document-level received status, defaulting to sent
- `RecipientsWithStatus` uses `limit: 1` in the React Query fetch to ensure the query key matches the detail page's own load, reading from cache without extra requests
- Status dot styling uses Tailwind classes (`bg-green-500`, `bg-blue-500`, `bg-red-500`) for consistency with the design system
- Maintains i18n tooltips in French for all three delivery states

https://claude.ai/code/session_01Wc1HrZJdx4bZBvngdsAtT2